### PR TITLE
Add play icon to Start Task CodeLens in spec provider

### DIFF
--- a/src/providers/spec-task-code-lens-provider.ts
+++ b/src/providers/spec-task-code-lens-provider.ts
@@ -32,7 +32,7 @@ export class SpecTaskCodeLensProvider implements vscode.CodeLensProvider {
 
                 // Create CodeLens
                 const codeLens = new vscode.CodeLens(range, {
-                    title: "▶ Start Task",
+                    title: "$(play) Start Task",
                     tooltip: "Click to execute this task",
                     command: "kfc.spec.implTask",
                     arguments: [document.uri, i, taskDescription]


### PR DESCRIPTION
Update the CodeLens title to include a play icon (using VS Code's icon syntax) for better visual indication of the task execution action. This improves UI consistency with VS Code's common action patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the Start Task CodeLens to display the VS Code play icon alongside the label ("$(play) Start Task").
  - This change affects the appearance in the editor gutter only; range, tooltip, command, and arguments are unchanged.
  - No functional impact or API changes.
  - Users will see a play icon next to the action text when hovering or in-line where CodeLens appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->