### PR TITLE
Refactor config handling and update documentation

### DIFF
--- a/.codex/settings/kfc-settings.json
+++ b/.codex/settings/kfc-settings.json
@@ -1,0 +1,8 @@
+{
+  "paths": {
+    "specs": ".codex/specs",
+    "steering": ".codex/steering",
+    "settings": ".codex/settings",
+    "prompts": ".codex/prompts"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ Core commands registered by the extension:
 
 ## Configuration
 
-Settings are stored in `.codex/settings/kfc-settings.json`:
+Project-local settings are stored in `.codex/settings/kfc-settings.json` and only contain paths. UI visibility and Codex runtime options live in VS Code settings under the `kfc.*` namespace.
+
+Minimal settings file:
 
 ```json
 {
@@ -155,25 +157,14 @@ Settings are stored in `.codex/settings/kfc-settings.json`:
     "steering": ".codex/steering",
     "settings": ".codex/settings",
     "prompts": ".codex/prompts"
-  },
-  "views": {
-    "specs": { "visible": true },
-    "steering": { "visible": true },
-    "prompts": { "visible": true },
-    "mcp": { "visible": false },
-    "hooks": { "visible": false },
-    "agents": { "visible": false },
-    "settings": { "visible": false }
-  },
-  "codex": {
-    "path": "codex",
-    "defaultApprovalMode": "interactive",
-    "defaultModel": "gpt-5",
-    "timeout": 30000,
-    "terminalDelay": 1000
   }
 }
 ```
+
+Notes:
+- Only the `paths.*` values are honored by the extension at runtime.
+- Changing `paths.*` may require a window reload to take effect.
+- The location of `kfc-settings.json` itself is fixed to `.codex/settings/kfc-settings.json` (editing `paths.settings` does not relocate the file).
 
 ## Workspace Structure
 

--- a/src/utils/config-manager.ts
+++ b/src/utils/config-manager.ts
@@ -1,26 +1,9 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { CONFIG_FILE_NAME, DEFAULT_PATHS, DEFAULT_VIEW_VISIBILITY } from '../constants';
+import { CONFIG_FILE_NAME, DEFAULT_PATHS } from '../constants';
 
-export enum ApprovalMode {
-    Interactive = 'interactive',
-    AutoEdit = 'auto-edit',
-    FullAuto = 'full-auto'
-}
-
-export interface CodexConfig {
-    path: string;
-    defaultApprovalMode: ApprovalMode;
-    defaultModel?: string;
-    timeout: number;
-    terminalDelay: number;
-}
-
-export interface MigrationConfig {
-    backupOriginalFiles: boolean;
-    migrationCompleted: boolean;
-}
-
+// Minimal project-local settings persisted under .codex/settings/kfc-settings.json
+// Only "paths" are honored by the extension. Other runtime configs live in VS Code settings (kfc.*).
 export interface KfcSettings {
     paths: {
         specs: string;
@@ -28,16 +11,6 @@ export interface KfcSettings {
         settings: string;
         prompts: string;
     };
-    views: {
-        specs: { visible: boolean; };
-        steering: { visible: boolean; };
-        mcp: { visible: boolean; };
-        hooks: { visible: boolean; };
-        prompts: { visible: boolean; };
-        settings: { visible: boolean; };
-    };
-    codex?: CodexConfig;
-    migration?: MigrationConfig;
 }
 
 export class ConfigManager {
@@ -108,34 +81,7 @@ export class ConfigManager {
 
     private getDefaultSettings(): KfcSettings {
         return {
-            paths: { ...DEFAULT_PATHS },
-            views: {
-                specs: { visible: DEFAULT_VIEW_VISIBILITY.specs },
-                steering: { visible: DEFAULT_VIEW_VISIBILITY.steering },
-                mcp: { visible: DEFAULT_VIEW_VISIBILITY.mcp },
-                hooks: { visible: DEFAULT_VIEW_VISIBILITY.hooks },
-                prompts: { visible: DEFAULT_VIEW_VISIBILITY.prompts },
-                settings: { visible: DEFAULT_VIEW_VISIBILITY.settings }
-            },
-            codex: this.getDefaultCodexConfig(),
-            migration: this.getDefaultMigrationConfig()
-        };
-    }
-
-    private getDefaultCodexConfig(): CodexConfig {
-        return {
-            path: 'codex',
-            defaultApprovalMode: ApprovalMode.Interactive,
-            defaultModel: 'gpt-5',
-            timeout: 30000,
-            terminalDelay: 1000
-        };
-    }
-
-    private getDefaultMigrationConfig(): MigrationConfig {
-        return {
-            backupOriginalFiles: true,
-            migrationCompleted: false
+            paths: { ...DEFAULT_PATHS }
         };
     }
 
@@ -162,135 +108,5 @@ export class ConfigManager {
         this.settings = settings;
     }
 
-    // Codex Configuration Methods
-    getCodexConfig(): CodexConfig {
-        const settings = this.getSettings();
-        return settings.codex || this.getDefaultCodexConfig();
-    }
-
-    async updateCodexConfig(config: Partial<CodexConfig>): Promise<void> {
-        const settings = this.getSettings();
-        settings.codex = { ...this.getCodexConfig(), ...config };
-        await this.saveSettings(settings);
-    }
-
-    async validateCodexPath(codexPath?: string): Promise<{ isValid: boolean; error?: string; }> {
-        const pathToCheck = codexPath || this.getCodexConfig().path;
-
-        try {
-            // Check if codex command is available
-            const { spawn } = require('child_process');
-
-            return new Promise((resolve) => {
-                const process = spawn(pathToCheck, ['--version'], {
-                    stdio: 'pipe',
-                    timeout: 5000
-                });
-
-                let output = '';
-                process.stdout?.on('data', (data: Buffer) => {
-                    output += data.toString();
-                });
-
-                process.on('close', (code: number) => {
-                    if (code === 0) {
-                        resolve({ isValid: true });
-                    } else {
-                        resolve({
-                            isValid: false,
-                            error: `Codex CLI returned exit code ${code}`
-                        });
-                    }
-                });
-
-                process.on('error', (error: Error) => {
-                    resolve({
-                        isValid: false,
-                        error: `Failed to execute Codex CLI: ${error.message}`
-                    });
-                });
-            });
-        } catch (error) {
-            return {
-                isValid: false,
-                error: `Error validating Codex path: ${error instanceof Error ? error.message : 'Unknown error'}`
-            };
-        }
-    }
-
-    // Migration Methods
-    getMigrationConfig(): MigrationConfig {
-        const settings = this.getSettings();
-        return settings.migration || this.getDefaultMigrationConfig();
-    }
-
-    async updateMigrationConfig(config: Partial<MigrationConfig>): Promise<void> {
-        const settings = this.getSettings();
-        settings.migration = { ...this.getMigrationConfig(), ...config };
-        await this.saveSettings(settings);
-    }
-
-    // Approval Mode Management
-    async setApprovalMode(mode: ApprovalMode): Promise<void> {
-        await this.updateCodexConfig({ defaultApprovalMode: mode });
-    }
-
-    getApprovalMode(): ApprovalMode {
-        return this.getCodexConfig().defaultApprovalMode;
-    }
-
-    // Codex CLI Availability Check
-    async checkCodexAvailability(): Promise<{ available: boolean; version?: string; error?: string; }> {
-        const validation = await this.validateCodexPath();
-
-        if (!validation.isValid) {
-            return {
-                available: false,
-                error: validation.error
-            };
-        }
-
-        try {
-            const codexPath = this.getCodexConfig().path;
-            const { spawn } = require('child_process');
-
-            return new Promise((resolve) => {
-                const process = spawn(codexPath, ['--version'], {
-                    stdio: 'pipe',
-                    timeout: 5000
-                });
-
-                let output = '';
-                process.stdout?.on('data', (data: Buffer) => {
-                    output += data.toString();
-                });
-
-                process.on('close', (code: number) => {
-                    if (code === 0) {
-                        // Extract version from output
-                        const versionMatch = output.match(/(\d+\.\d+\.\d+)/);
-                        const version = versionMatch ? versionMatch[1] : 'unknown';
-                        resolve({ available: true, version });
-                    } else {
-                        resolve({
-                            available: false,
-                            error: `Codex CLI returned exit code ${code}`
-                        });
-                    }
-                });
-
-                process.on('error', (error: Error) => {
-                    resolve({
-                        available: false,
-                        error: `Failed to check Codex version: ${error.message}`
-                    });
-                });
-            });
-        } catch (error) {
-            return {
-                available: false,
-                error: `Error checking Codex availability: ${error instanceof Error ? error.message : 'Unknown error'}`
-            };
-        }
-    }
+    // (Intentionally minimal) — legacy config sections (views/codex/migration) have been removed.
 }

--- a/tests/unit/utils/config-manager.test.ts
+++ b/tests/unit/utils/config-manager.test.ts
@@ -1,4 +1,4 @@
-import { ApprovalMode, CodexConfig, ConfigManager, MigrationConfig } from '../../../src/utils/config-manager';
+import { ConfigManager, KfcSettings } from '../../../src/utils/config-manager';
 
 // Mock vscode
 jest.mock('vscode', () => ({
@@ -11,190 +11,91 @@ jest.mock('vscode', () => ({
       writeFile: jest.fn().mockResolvedValue(undefined),
       readFile: jest.fn().mockResolvedValue(Buffer.from('{}'))
     },
-    getConfiguration: jest.fn(() => ({
-      get: jest.fn()
-    }))
+    getConfiguration: jest.fn(() => ({ get: jest.fn() }))
   },
   Uri: {
     file: jest.fn((path: string) => ({ fsPath: path }))
   }
 }));
 
-// Mock fs
-jest.mock('fs', () => ({
-  existsSync: jest.fn(),
-  promises: {
-    copyFile: jest.fn().mockResolvedValue(undefined),
-    writeFile: jest.fn().mockResolvedValue(undefined),
-    readFile: jest.fn().mockResolvedValue('')
-  }
-}));
-
-// Mock child_process
-jest.mock('child_process', () => ({
-  spawn: jest.fn()
-}));
-
-describe('ConfigManager Codex Integration', () => {
+describe('ConfigManager (paths-only settings)', () => {
   let configManager: ConfigManager;
   const vscode = require('vscode');
-  const fs = require('fs');
-  const { spawn } = require('child_process');
 
   beforeEach(() => {
     jest.clearAllMocks();
     configManager = ConfigManager.getInstance();
   });
 
-  describe('Codex Configuration', () => {
-    test('should return default Codex config', () => {
-      const codexConfig = configManager.getCodexConfig();
+  test('returns default paths when file missing', async () => {
+    // Simulate file not found
+    (vscode.workspace.fs.readFile as jest.Mock).mockRejectedValueOnce(new Error('ENOENT'));
 
-      expect(codexConfig).toEqual({
-        path: 'codex',
-        defaultApprovalMode: ApprovalMode.Interactive,
-        defaultModel: 'gpt-5',
-        timeout: 30000,
-        terminalDelay: 1000
-      });
-    });
+    const settings = await configManager.loadSettings();
 
-    test('should update Codex config', async () => {
-      const newConfig: Partial<CodexConfig> = {
-        path: '/usr/local/bin/codex',
-        defaultApprovalMode: ApprovalMode.AutoEdit,
-        timeout: 45000
-      };
-
-      await configManager.updateCodexConfig(newConfig);
-
-      const updatedConfig = configManager.getCodexConfig();
-      expect(updatedConfig.path).toBe('/usr/local/bin/codex');
-      expect(updatedConfig.defaultApprovalMode).toBe(ApprovalMode.AutoEdit);
-      expect(updatedConfig.timeout).toBe(45000);
-      expect(updatedConfig.defaultModel).toBe('gpt-5'); // Should preserve existing values
-    });
-
-    test('should validate Codex path successfully', async () => {
-      const mockProcess = {
-        stdout: {
-          on: jest.fn((event, callback) => {
-            if (event === 'data') {
-              callback(Buffer.from('codex version 1.0.0'));
-            }
-          })
-        },
-        on: jest.fn((event, callback) => {
-          if (event === 'close') {
-            callback(0); // Success exit code
-          }
-        })
-      };
-
-      spawn.mockReturnValue(mockProcess);
-
-      const result = await configManager.validateCodexPath('codex');
-
-      expect(result.isValid).toBe(true);
-      expect(result.error).toBeUndefined();
-    });
-
-    test('should handle Codex path validation failure', async () => {
-      const mockProcess = {
-        stdout: {
-          on: jest.fn()
-        },
-        on: jest.fn((event, callback) => {
-          if (event === 'error') {
-            callback(new Error('Command not found'));
-          }
-        })
-      };
-
-      spawn.mockReturnValue(mockProcess);
-
-      const result = await configManager.validateCodexPath('invalid-codex');
-
-      expect(result.isValid).toBe(false);
-      expect(result.error).toContain('Failed to execute Codex CLI');
+    expect(settings.paths).toEqual({
+      specs: '.codex/specs',
+      steering: '.codex/steering',
+      settings: '.codex/settings',
+      prompts: '.codex/prompts'
     });
   });
 
-  describe('Migration Configuration', () => {
-    test('should return default migration config', () => {
-      const migrationConfig = configManager.getMigrationConfig();
+  test('merges paths from existing file', async () => {
+    const fileContent: KfcSettings = {
+      paths: {
+        specs: 'custom/specs',
+        steering: '.codex/steering',
+        settings: '.codex/settings',
+        prompts: '.codex/prompts'
+      }
+    };
+    (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValueOnce(
+      Buffer.from(JSON.stringify(fileContent))
+    );
 
-      expect(migrationConfig).toEqual({
-        backupOriginalFiles: true,
-        migrationCompleted: false
-      });
-    });
-
-    test('should update migration config', async () => {
-      const newConfig: Partial<MigrationConfig> = {
-        migrationCompleted: true
-      };
-
-      await configManager.updateMigrationConfig(newConfig);
-
-      const updatedConfig = configManager.getMigrationConfig();
-      expect(updatedConfig.migrationCompleted).toBe(true);
-      expect(updatedConfig.backupOriginalFiles).toBe(true); // Should preserve existing values
-    });
+    const settings = await configManager.loadSettings();
+    expect(settings.paths.specs).toBe('custom/specs');
+    // Unchanged keys fallback to defaults via merge
+    expect(settings.paths.prompts).toBe('.codex/prompts');
   });
 
-  describe('Approval Mode Management', () => {
-    test('should set and get approval mode', async () => {
-      await configManager.setApprovalMode(ApprovalMode.FullAuto);
+  test('getPath returns overridden or default value', async () => {
+    // Reset to defaults for this test
+    (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValueOnce(Buffer.from('{}'));
+    await configManager.loadSettings();
 
-      const mode = configManager.getApprovalMode();
-      expect(mode).toBe(ApprovalMode.FullAuto);
-    });
+    const specs = configManager.getPath('specs');
+    const prompts = configManager.getPath('prompts');
+    expect(specs).toBe('.codex/specs');
+    expect(prompts).toBe('.codex/prompts');
   });
 
-  describe('Codex Availability Check', () => {
-    test('should check Codex availability successfully', async () => {
-      const mockProcess = {
-        stdout: {
-          on: jest.fn((event, callback) => {
-            if (event === 'data') {
-              callback(Buffer.from('codex version 1.2.3'));
-            }
-          })
-        },
-        on: jest.fn((event, callback) => {
-          if (event === 'close') {
-            callback(0);
-          }
-        })
-      };
+  test('saveSettings writes only paths object', async () => {
+    const newSettings: KfcSettings = {
+      paths: {
+        specs: 's',
+        steering: 't',
+        settings: 'u',
+        prompts: 'v'
+      }
+    };
 
-      spawn.mockReturnValue(mockProcess);
+    await configManager.saveSettings(newSettings);
 
-      const result = await configManager.checkCodexAvailability();
+    expect(vscode.workspace.fs.writeFile).toHaveBeenCalled();
+    const [, content] = (vscode.workspace.fs.writeFile as jest.Mock).mock.calls[0];
+    const saved = JSON.parse(Buffer.from(content).toString());
+    expect(Object.keys(saved)).toEqual(['paths']);
+    expect(saved.paths).toEqual(newSettings.paths);
+  });
 
-      expect(result.available).toBe(true);
-      expect(result.version).toBe('1.2.3');
-    });
+  test('getAbsolutePath builds from workspace root', async () => {
+    // Reset to defaults for this test
+    (vscode.workspace.fs.readFile as jest.Mock).mockResolvedValueOnce(Buffer.from('{}'));
+    await configManager.loadSettings();
 
-    test('should handle Codex unavailability', async () => {
-      const mockProcess = {
-        stdout: {
-          on: jest.fn()
-        },
-        on: jest.fn((event, callback) => {
-          if (event === 'error') {
-            callback(new Error('Command not found'));
-          }
-        })
-      };
-
-      spawn.mockReturnValue(mockProcess);
-
-      const result = await configManager.checkCodexAvailability();
-
-      expect(result.available).toBe(false);
-      expect(result.error).toContain('Failed to execute Codex CLI');
-    });
+    const abs = configManager.getAbsolutePath('prompts');
+    expect(abs).toBe('/test/workspace/.codex/prompts');
   });
 });


### PR DESCRIPTION
- Move runtime settings to VS Code config (kfc.* namespace)
- Simplify project config to only handle paths in kfc-settings.json
- Update README to clarify configuration structure
- Remove unused config interfaces and methods from config-manager
- Add note about fixed settings file location

This change separates project-specific path configuration from runtime settings, making the extension more maintainable and user-configurable through VS Code settings UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified project-local settings to a paths-only file, mapping specs, steering, settings, and prompts directories.
  * Defaults are applied when no local settings exist; changes persist reliably.

* **Documentation**
  * Updated Configuration guide with a minimal paths-only example.
  * Clarified that UI visibility and runtime options now live in VS Code settings (kfc.*).
  * Added notes: only paths.* are honored at runtime, changing paths may require a window reload, and the settings file location is fixed.

* **Tests**
  * Updated unit tests to cover the new paths-only configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->