### PR TITLE
Bump version to 0.1.1 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kiro-for-codex",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kiro-for-codex",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "gray-matter": "^4.0.3",
         "handlebars": "^4.7.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kiro-for-codex",
   "displayName": "Kiro for Codex",
   "description": "Spec-driven development with Codex CLI - inspired by Kiro",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "atman-33",
   "publisher": "atman-dev",
   "icon": "icon.png",


### PR DESCRIPTION
Update package version from 0.1.0 to 0.1.1 to reflect new changes in the codebase. This version bump ensures consistency between both package files.