### PR TITLE
Add steering documentation and related implementation files

### DIFF
--- a/.codex/steering/product.md
+++ b/.codex/steering/product.md
@@ -1,0 +1,37 @@
+# Product Steering
+
+Use this guide to keep the VS Code extension "Kiro for Codex" aligned with its purpose and workflow.
+
+## Purpose & Value
+- Provide a spec‑driven development workflow powered by Codex CLI inside VS Code.
+- Let users manage Specs, Steering docs, and Prompts visually via tree views.
+- Reduce ambiguity by guiding AI actions with repository‑specific rules and paths.
+
+## Core Features (enforce in code/UX)
+- Spec Workflow: Requirements → Design → Tasks with explicit approvals.
+  - Navigate via commands `kfc.spec.navigate.*` and CodeLens on `tasks.md`.
+- Steering Docs: generate and edit guidance under `.codex/steering/`.
+- Prompts: scaffold and run `.codex/prompts/<name>.md` in split terminal with Codex CLI.
+- Settings bootstrap: create `.codex/settings/kfc-settings.json` with defaults on first run.
+- Codex availability checks and setup guidance if missing or incompatible.
+
+## User Value Proposition
+- Consistent, reviewable planning before implementation (Specs cadence and approvals).
+- One‑click execution of individual tasks from `tasks.md` with automatic check‑off.
+- Centralized, discoverable guidance (Steering) that shapes AI behavior per project.
+
+## Business Logic Rules (follow strictly)
+- Paths come from `ConfigManager.getPath(...)` and default to `DEFAULT_CONFIG.paths` (see `src/constants.ts`, `src/utils/config-manager.ts`). Never hardcode absolute paths.
+- Create directories/files inside `.codex/` only when missing; do not overwrite user content.
+- Gate disabled features by flags in `src/constants.ts`:
+  - `ENABLE_SPEC_AGENTS`, `ENABLE_AGENTS_UI`, `ENABLE_HOOKS_UI`, `ENABLE_MCP_UI` must be respected in UI and command registration.
+- Require Codex CLI readiness before actions that invoke it; surface `showSetupGuidance` on failure (`src/providers/codex-provider.ts`).
+- Keep the Spec order: generate Requirements → wait for approval → Design → approval → Tasks. In navigation, show placeholder docs with guidance if files are absent (`SpecManager.navigateToDocument`).
+- Write task completion as Markdown checkbox replacement `- [ ]` → `- [x]` when executing a task (`kfc.spec.implTask`).
+- Maintain `.codex` watcher-based auto-refresh of tree views; avoid long-running synchronous work on the extension host thread.
+
+## Examples
+- Spec base path resolution: `SpecManager.getSpecBasePath()` returns `.codex/specs` by default.
+- Steering generation entry: `kfc.steering.generateInitial` uses `src/prompts/target/steering/init-steering.ts` through `PromptLoader`.
+- Packaging is extension-first; CLIs are invoked via terminal using `CommandBuilder` to assemble flags and model.
+

--- a/.codex/steering/structure.md
+++ b/.codex/steering/structure.md
@@ -1,0 +1,43 @@
+# Structure Steering
+
+Follow this organization and naming to keep the codebase consistent.
+
+## Directory Map (high level)
+- `src/`
+  - `extension.ts` — activation, providers/commands wiring
+  - `constants.ts` — defaults, flags, versions
+  - `features/` — business flows
+    - `spec/spec-manager.ts`
+    - `steering/steering-manager.ts`
+  - `providers/` — VS Code TreeDataProviders & UI glue
+    - `*/*-provider.ts` (e.g., `spec-explorer-provider.ts`, `steering-explorer-provider.ts`)
+  - `services/` — cross-cutting services (`command-builder.ts`, `process-manager.ts`, `prompt-loader.ts`, etc.)
+  - `utils/` — helpers (`config-manager.ts`, `notification-utils.ts`, `update-checker.ts`)
+  - `prompts/` — authorable markdown sources; built artifacts under `prompts/target/`
+  - `resources/` — agent/system prompt materials
+- `.codex/` (workspace data written by the extension)
+  - `specs/<spec>/requirements.md|design.md|tasks.md`
+  - `steering/product.md|tech.md|structure.md`
+  - `prompts/<name>.md`
+  - `settings/kfc-settings.json`
+
+## Naming Patterns
+- Providers: `*-provider.ts` exporting a class named `PascalCase...Provider`.
+- Managers: `*-manager.ts` exposing cohesive actions for a feature domain.
+- Types: shared interfaces under `src/types/` with `-types.ts` suffix.
+- Prompts: author in `src/prompts/.../*.md`; generated TS entry points under `src/prompts/target/*`.
+
+## Component Boundaries
+- UI (providers) must delegate execution to managers; do not perform filesystem/process work directly in providers.
+- Managers must use `ConfigManager` for all `.codex` paths and must not hardcode directories.
+- CLI interactions go through `CodexProvider` and `CommandBuilder`; do not spawn processes ad hoc.
+- Long-running actions must surface progress via VS Code notifications and use split terminals for Codex runs.
+
+## Key Files
+- Entry/activation: `src/extension.ts`
+- Defaults/flags: `src/constants.ts`
+- Spec flow: `src/features/spec/spec-manager.ts`
+- Steering flow: `src/features/steering/steering-manager.ts`
+- Codex CLI glue: `src/providers/codex-provider.ts`, `src/services/command-builder.ts`
+- Settings path resolution: `src/utils/config-manager.ts`
+

--- a/.codex/steering/tech.md
+++ b/.codex/steering/tech.md
@@ -1,0 +1,44 @@
+# Technical Steering
+
+Use these conventions when building and maintaining the extension.
+
+## Tech Stack
+- VS Code Extension (TypeScript)
+- Node.js 16+
+- Bundling: Webpack 5 (production build uses hidden source maps)
+- Packaging: `vsce`
+- Testing: Jest + ts-jest
+- Templates/Prompts: Handlebars, gray-matter, js-yaml
+- External runtime: Codex CLI (min version from `MIN_CODEX_CLI_VERSION`)
+
+## Build System & Scripts (package.json)
+- `npm run compile`: build prompts → `tsc` → `vsce package`
+- `npm run watch`: `tsc -w` + prompt watcher
+- `npm run package`: create `.vsix`
+- `npm run package-web`: production webpack build (used by `build` & `vscode:prepublish`)
+- Tests: `npm test`, `npm run test:watch`, `npm run test:coverage`
+
+## Codex CLI Integration
+- Build commands via `CommandBuilder` (`src/services/command-builder.ts`).
+  - Approval mode flags: `-a on-request` | `-a on-failure` | `--full-auto`.
+  - Model flag: `-m <model>`. Working directory: `-C <path>`.
+- Resolve default paths/settings via `ConfigManager` and `DEFAULT_CONFIG`.
+- Check availability and show guidance using `CodexProvider` before invoking.
+
+## Common Commands (developer)
+- Build: `npm run compile` or `npm run package-web`
+- Run (VS Code): press F5 (Extension Development Host)
+- Package: `npm run package` → `kiro-for-codex-<version>.vsix`
+- Tests: `npm test`
+
+## Project-Specific Conventions
+- File layout under `src/`:
+  - Entry: `extension.ts`; constants in `constants.ts`.
+  - Feature managers under `features/<domain>/*-manager.ts` (e.g., `spec-manager.ts`, `steering-manager.ts`).
+  - Tree providers under `providers/*-provider.ts`.
+  - Services encapsulate IO/process concerns in `services/` (prompt loading, error handling, command building, retries).
+  - Prompt sources in `src/prompts` with generated TypeScript in `src/prompts/target`.
+- Respect feature flags in `src/constants.ts` to hide/disable views and commands.
+- Only `paths.*` in `.codex/settings/kfc-settings.json` affect runtime resolution; other behavior is configured via VS Code settings (`kfc.*`).
+- Never block the extension host thread; use VS Code progress notifications and split terminal for long Codex runs.
+

--- a/src/features/steering/steering-manager.ts
+++ b/src/features/steering/steering-manager.ts
@@ -188,31 +188,10 @@ export class SteeringManager {
      */
     async createProjectDocumentation() {
         try {
-            const prompt = `# Task: Initialize AGENTS.md Configuration
-
-## Context
-Create an AGENTS.md file that provides agent configuration and guidance for Codex CLI when working with this codebase.
-
-## Expected Output
-Create an AGENTS.md file in the project root that includes:
-- Project overview and purpose
-- Agent behavior guidelines
-- Code style preferences
-- Architecture patterns to follow
-- Testing requirements
-- Development workflow instructions
-
-## Constraints
-- Analyze the existing codebase structure
-- Include specific examples from the project
-- Focus on actionable guidance for Codex CLI
-- Use clear, imperative language
-- Structure content for easy agent parsing
-
-## File Location
-Create the file as AGENTS.md in the project root directory.
-
-Begin by analyzing the project structure and creating the AGENTS.md configuration file.`;
+            const prompt = this.promptLoader.renderPrompt('create-agents-md', {
+                steeringPath: this.getSteeringBasePath(),
+                constantsPath: 'src/constants.ts'
+            });
 
             await this.codexProvider.invokeCodexSplitView(prompt, 'Codex -Create AGENTS.md');
 

--- a/src/prompts/steering/create-agents-md.md
+++ b/src/prompts/steering/create-agents-md.md
@@ -1,0 +1,90 @@
+---
+id: create-agents-md
+name: Create or Update AGENTS.md (Reference-First)
+version: 1.0.0
+description: Generate a non-duplicative, reference-first AGENTS.md that indexes Steering docs and defines the agent contract.
+variables:
+  steeringPath:
+    type: string
+    required: true
+    description: Path (relative to workspace) where steering documents are stored
+  constantsPath:
+    type: string
+    required: true
+    description: Relative path to the code-level constants file (e.g., src/constants.ts)
+---
+
+<system>
+You are generating AGENTS.md for this repository.
+
+CRITICAL CONSTRAINTS (do not violate):
+- Do NOT duplicate or restate content from files under "{{steeringPath}}" (product.md, tech.md, structure.md). Reference them instead.
+- Do NOT include explicit numeric/version values pulled from code (e.g., the actual value of MIN_CODEX_CLI_VERSION). Reference identifiers/locations only.
+- Keep AGENTS.md concise, scan-friendly, and machine-parseable. Prefer short sections with bullets over narrative.
+- Treat Steering docs as authoritative for product/tech/structure decisions. AGENTS.md is an index and contract, not a duplicate.
+
+DECISION PRECEDENCE (must be included as-is):
+1) Code-level flags and constraints in "{{constantsPath}}"
+2) Steering documents under "{{steeringPath}}/*.md"
+3) This AGENTS.md contract (general repository conventions)
+4) Generic assumptions (avoid unless explicitly allowed)
+
+STYLE:
+- Use imperative bullets ("Use X", "Avoid Y").
+- Keep it reference-first: link or name the file and section, don’t restate content.
+- Avoid generic best practices unless needed to glue rules together.
+</system>
+
+# AGENTS.md — Kiro for Codex
+
+This file defines the agent contract and serves as the index to project guidance. It applies repo-wide unless overridden by a nested AGENTS.md.
+
+## Steering Documents
+- Purpose: Treat Steering as the first-party source for product, technical, and structural guidance.
+- Location: "{{steeringPath}}/product.md", "{{steeringPath}}/tech.md", "{{steeringPath}}/structure.md".
+- Access: Resolve paths via ConfigManager (e.g., `ConfigManager.getPath('steering')`). Never hardcode absolute paths.
+- Mutations: Treat Steering as read-only; update via feature flows (Init/Refine/Delete) rather than ad-hoc edits.
+- Usage: Summarize applicable Steering points in outputs; cite the specific file/section without restating details.
+
+## Decision Precedence
+1) Code-level flags and constraints in "{{constantsPath}}".
+2) Steering documents under "{{steeringPath}}/*.md".
+3) This AGENTS.md contract (general repository conventions).
+4) Generic assumptions (avoid unless explicitly allowed).
+
+## Agent Behavior Contract
+- Prefer CodexProvider for CLI operations; use ProcessManager/CommandBuilder; never spawn child processes directly.
+- Respect feature flags in "{{constantsPath}}" and any `package.json` `contributes.*` gating.
+- Logging: Use the shared OutputChannel; log key lifecycle and error paths; avoid noisy logs.
+- Error handling: Use centralized services (ErrorHandler/RetryService); avoid ad-hoc try/catch loops.
+- Performance/UX: Do not block the extension host; long tasks use split terminals and VS Code progress notifications.
+- Reference Steering for specifics (naming, boundaries, directory layout) rather than restating them here.
+
+## Paths & I/O
+- Workspace I/O: Prefer VS Code FS APIs (`vscode.workspace.fs`) for read/write/create.
+- Path resolution: Use ConfigManager for all `.codex/*` paths; avoid absolute paths.
+- Write boundaries: Only write within `.codex/**`, the workspace, or VS Code storage as allowed by project rules.
+- Steering: Do not overwrite files under `{{steeringPath}}` directly; use feature flows.
+
+## CLI Integration
+- Build CLI arguments with CommandBuilder; execute via ProcessManager.
+- Approval modes and model flags: Reference their definition sites/tests without duplicating values.
+- Verify Codex availability before invocation; surface setup guidance if unavailable.
+
+## Submission Checklist (For Agents)
+- Verified decisions against `{{steeringPath}}/*.md`; cited files/sections without duplication.
+- Resolved steering path via ConfigManager; avoided absolute paths.
+- Respected feature flags and constraints in `{{constantsPath}}`.
+- Used CodexProvider/CommandBuilder/ProcessManager for CLI interactions.
+- Avoided restating Steering or code constants; kept AGENTS.md concise and index-like.
+
+## Non‑Goals / Anti‑Patterns
+- Do not bypass CodexProvider/ProcessManager for CLI calls.
+- Do not store state in globals beyond established singletons.
+- Do not write outside approved directories or overwrite Steering directly.
+- Do not re-enable disabled features unless explicitly requested.
+
+## Instructions to Apply
+- Write or update `AGENTS.md` at the repository root with the structure above.
+- If an AGENTS.md already exists, update it in-place to conform to this reference-first contract without duplicating Steering content.
+

--- a/src/prompts/target/index.ts
+++ b/src/prompts/target/index.ts
@@ -1,9 +1,10 @@
 // Auto-generated index file
 // Re-export all prompt modules
 
-export { default as createSpec } from './spec/create-spec';
 export { default as createSpecWithAgents } from './spec/create-spec-with-agents';
+export { default as createSpec } from './spec/create-spec';
 export { default as implTask } from './spec/impl-task';
+export { default as createAgentsMd } from './steering/create-agents-md';
 export { default as createCustomSteering } from './steering/create-custom-steering';
 export { default as deleteSteering } from './steering/delete-steering';
 export { default as initSteering } from './steering/init-steering';

--- a/src/prompts/target/steering/create-agents-md.ts
+++ b/src/prompts/target/steering/create-agents-md.ts
@@ -1,0 +1,28 @@
+// Auto-generated from src/prompts/steering/create-agents-md.md
+// DO NOT EDIT MANUALLY
+
+export const frontmatter = {
+  "id": "create-agents-md",
+  "name": "Create or Update AGENTS.md (Reference-First)",
+  "version": "1.0.0",
+  "description": "Generate a non-duplicative, reference-first AGENTS.md that indexes Steering docs and defines the agent contract.",
+  "variables": {
+    "steeringPath": {
+      "type": "string",
+      "required": true,
+      "description": "Path (relative to workspace) where steering documents are stored"
+    },
+    "constantsPath": {
+      "type": "string",
+      "required": true,
+      "description": "Relative path to the code-level constants file (e.g., src/constants.ts)"
+    }
+  }
+};
+
+export const content = "\n<system>\nYou are generating AGENTS.md for this repository.\n\nCRITICAL CONSTRAINTS (do not violate):\n- Do NOT duplicate or restate content from files under \"{{steeringPath}}\" (product.md, tech.md, structure.md). Reference them instead.\n- Do NOT include explicit numeric/version values pulled from code (e.g., the actual value of MIN_CODEX_CLI_VERSION). Reference identifiers/locations only.\n- Keep AGENTS.md concise, scan-friendly, and machine-parseable. Prefer short sections with bullets over narrative.\n- Treat Steering docs as authoritative for product/tech/structure decisions. AGENTS.md is an index and contract, not a duplicate.\n\nDECISION PRECEDENCE (must be included as-is):\n1) Code-level flags and constraints in \"{{constantsPath}}\"\n2) Steering documents under \"{{steeringPath}}/*.md\"\n3) This AGENTS.md contract (general repository conventions)\n4) Generic assumptions (avoid unless explicitly allowed)\n\nSTYLE:\n- Use imperative bullets (\"Use X\", \"Avoid Y\").\n- Keep it reference-first: link or name the file and section, don’t restate content.\n- Avoid generic best practices unless needed to glue rules together.\n</system>\n\n# AGENTS.md — Kiro for Codex\n\nThis file defines the agent contract and serves as the index to project guidance. It applies repo-wide unless overridden by a nested AGENTS.md.\n\n## Steering Documents\n- Purpose: Treat Steering as the first-party source for product, technical, and structural guidance.\n- Location: \"{{steeringPath}}/product.md\", \"{{steeringPath}}/tech.md\", \"{{steeringPath}}/structure.md\".\n- Access: Resolve paths via ConfigManager (e.g., `ConfigManager.getPath('steering')`). Never hardcode absolute paths.\n- Mutations: Treat Steering as read-only; update via feature flows (Init/Refine/Delete) rather than ad-hoc edits.\n- Usage: Summarize applicable Steering points in outputs; cite the specific file/section without restating details.\n\n## Decision Precedence\n1) Code-level flags and constraints in \"{{constantsPath}}\".\n2) Steering documents under \"{{steeringPath}}/*.md\".\n3) This AGENTS.md contract (general repository conventions).\n4) Generic assumptions (avoid unless explicitly allowed).\n\n## Agent Behavior Contract\n- Prefer CodexProvider for CLI operations; use ProcessManager/CommandBuilder; never spawn child processes directly.\n- Respect feature flags in \"{{constantsPath}}\" and any `package.json` `contributes.*` gating.\n- Logging: Use the shared OutputChannel; log key lifecycle and error paths; avoid noisy logs.\n- Error handling: Use centralized services (ErrorHandler/RetryService); avoid ad-hoc try/catch loops.\n- Performance/UX: Do not block the extension host; long tasks use split terminals and VS Code progress notifications.\n- Reference Steering for specifics (naming, boundaries, directory layout) rather than restating them here.\n\n## Paths & I/O\n- Workspace I/O: Prefer VS Code FS APIs (`vscode.workspace.fs`) for read/write/create.\n- Path resolution: Use ConfigManager for all `.codex/*` paths; avoid absolute paths.\n- Write boundaries: Only write within `.codex/**`, the workspace, or VS Code storage as allowed by project rules.\n- Steering: Do not overwrite files under `{{steeringPath}}` directly; use feature flows.\n\n## CLI Integration\n- Build CLI arguments with CommandBuilder; execute via ProcessManager.\n- Approval modes and model flags: Reference their definition sites/tests without duplicating values.\n- Verify Codex availability before invocation; surface setup guidance if unavailable.\n\n## Submission Checklist (For Agents)\n- Verified decisions against `{{steeringPath}}/*.md`; cited files/sections without duplication.\n- Resolved steering path via ConfigManager; avoided absolute paths.\n- Respected feature flags and constraints in `{{constantsPath}}`.\n- Used CodexProvider/CommandBuilder/ProcessManager for CLI interactions.\n- Avoided restating Steering or code constants; kept AGENTS.md concise and index-like.\n\n## Non‑Goals / Anti‑Patterns\n- Do not bypass CodexProvider/ProcessManager for CLI calls.\n- Do not store state in globals beyond established singletons.\n- Do not write outside approved directories or overwrite Steering directly.\n- Do not re-enable disabled features unless explicitly requested.\n\n## Instructions to Apply\n- Write or update `AGENTS.md` at the repository root with the structure above.\n- If an AGENTS.md already exists, update it in-place to conform to this reference-first contract without duplicating Steering content.\n\n";
+
+export default {
+  frontmatter,
+  content
+};

--- a/tests/unit/features/steering/steering-manager.test.ts
+++ b/tests/unit/features/steering/steering-manager.test.ts
@@ -1,0 +1,101 @@
+import * as vscode from 'vscode';
+import { SteeringManager } from '../../../../src/features/steering/steering-manager';
+import { CodexProvider } from '../../../../src/providers/codex-provider';
+
+// Mock vscode
+jest.mock('vscode', () => ({
+  window: {
+    showInputBox: jest.fn(),
+    showErrorMessage: jest.fn(),
+    withProgress: jest.fn(),
+    showWarningMessage: jest.fn()
+  },
+  workspace: {
+    workspaceFolders: [{ uri: { fsPath: '/test/workspace' } }],
+    fs: {
+      createDirectory: jest.fn(),
+      readDirectory: jest.fn(),
+      stat: jest.fn(),
+      delete: jest.fn(),
+      writeFile: jest.fn()
+    },
+    openTextDocument: jest.fn()
+  },
+  Uri: {
+    file: jest.fn((p) => ({ fsPath: p }))
+  },
+  FileType: { File: 1, Directory: 2 },
+  ProgressLocation: { Notification: 15 }
+}));
+
+// Mock CodexProvider
+jest.mock('../../../../src/providers/codex-provider');
+
+// Mock NotificationUtils
+jest.mock('../../../../src/utils/notification-utils', () => ({
+  NotificationUtils: {
+    showAutoDismissNotification: jest.fn()
+  }
+}));
+
+// Mock PromptLoader
+const renderPromptMock = jest.fn(() => 'mocked prompt content');
+jest.mock('../../../../src/services/prompt-loader', () => ({
+  PromptLoader: {
+    getInstance: jest.fn(() => ({
+      renderPrompt: renderPromptMock
+    }))
+  }
+}));
+
+// Mock ConfigManager
+const getPathMock = jest.fn((key: string) => (key === 'steering' ? '.codex/steering' : ''));
+jest.mock('../../../../src/utils/config-manager', () => ({
+  ConfigManager: {
+    getInstance: jest.fn(() => ({
+      loadSettings: jest.fn(),
+      getPath: getPathMock
+    }))
+  }
+}));
+
+describe('SteeringManager.createProjectDocumentation', () => {
+  let steeringManager: SteeringManager;
+  let mockCodexProvider: jest.Mocked<CodexProvider>;
+  let mockOutputChannel: any;
+
+  beforeEach(() => {
+    mockOutputChannel = {
+      appendLine: jest.fn(),
+      show: jest.fn(),
+      dispose: jest.fn()
+    };
+
+    mockCodexProvider = {
+      invokeCodexSplitView: jest.fn().mockResolvedValue({} as any),
+      getCodexConfig: jest.fn(() => ({ defaultApprovalMode: 'interactive' }))
+    } as unknown as jest.Mocked<CodexProvider>;
+
+    steeringManager = new SteeringManager(mockCodexProvider, mockOutputChannel);
+    renderPromptMock.mockClear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the create-agents-md prompt with correct variables and invokes Codex', async () => {
+    await steeringManager.createProjectDocumentation();
+
+    expect(renderPromptMock).toHaveBeenCalledWith('create-agents-md', {
+      steeringPath: '.codex/steering',
+      constantsPath: 'src/constants.ts'
+    });
+
+    expect(mockCodexProvider.invokeCodexSplitView).toHaveBeenCalledWith(
+      'mocked prompt content',
+      'Codex -Create AGENTS.md'
+    );
+  });
+});
+


### PR DESCRIPTION
- Add product, structure, and tech steering docs in `.codex/steering/` to guide development
- Implement steering manager and tests for handling steering documents
- Update build-prompts script and target index to support new steering prompts
- Add create-agents prompt markdown and TypeScript implementation
- Maintain consistent structure and naming patterns as outlined in new docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added template-driven generation of AGENTS.md within the steering workflow.
* Documentation
  * Introduced Product Steering, Structure, and Technical Steering guides to clarify workflows, architecture, and tooling.
* Refactor
  * Steering document creation now uses a prompt template instead of hard‑coded content.
* Chores
  * Prompt build script now auto-generates an index to consistently expose all prompts.
  * Added export for the new AGENTS.md prompt.
* Tests
  * Added unit tests verifying AGENTS.md generation via the steering manager and prompt loader.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->