### PR TITLE
Fix GitHub Actions output syntax and improve package.json version read

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -49,8 +49,8 @@ jobs:
             *) echo "::error::Unknown release_type: $TYPE"; exit 1; ;;
           esac
           NEXT_VERSION="$MAJOR.$MINOR.$PATCH"
-          echo "CURRENT_VERSION=$CURRENT" >> $GITHUB_OUTPUT
-          echo "NEXT_VERSION=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "NEXT_VERSION=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
 
           # Require a corresponding heading in CHANGELOG.md
           if ! grep -Eq "^## \\[$NEXT_VERSION\\]" CHANGELOG.md; then
@@ -69,7 +69,9 @@ jobs:
 
       - name: Read package.json version
         id: pkg
-        run: echo "PKG_VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "PKG_VERSION=$PKG_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Configure Git user
         run: |


### PR DESCRIPTION
- Use proper quoting for GITHUB_OUTPUT variable in version bump workflow
- Improve package.json version read by using separate command and variable
- Maintain consistency with GitHub Actions best practices for output handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved reliability of the version-bump workflow by quoting GitHub output paths and restructuring commands into a clearer multi-line shell block.
  - Ensures safer handling of outputs when reading and exporting the package version.
  - Release calculation logic remains the same.
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->