### PR TITLE
Avoid name collision with Kiro for Claude Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ## v0.2.0 2025-09-09
 
+### Breaking
+
+- Rename internal namespace from `kfc` to `kiroCodex` to avoid collisions with the original extension and make the identifier explicit.
+  - Commands: `kfc.*` → `kiroCodex.*`
+  - Views and container IDs: `kfc.views.*` → `kiroCodex.views.*`
+  - Settings namespace: `kfc.*` → `kiroCodex.*`
+  - Project settings file: `.codex/settings/kfc-settings.json` → `.codex/settings/kiroCodex-settings.json`
+  - Built-in agents directory: `.codex/agents/kfc` → `.codex/agents/kiroCodex`
+
 ### Changed
 
 - bug-fix/changelog-workflow
@@ -40,8 +49,8 @@ All notable changes to this project will be documented in this file.
 ### 🔧 Improvements
 
 - Refactor configuration handling:
-  - Move runtime settings to VS Code settings under the `kfc.*` namespace.
-  - Simplify project configuration to only manage paths via `.codex/settings/kfc-settings.json`.
+  - Move runtime settings to VS Code settings under the `kiroCodex.*` namespace.
+  - Simplify project configuration to only manage paths via `.codex/settings/kiroCodex-settings.json`.
   - Remove unused configuration interfaces/methods in `src/utils/config-manager.ts` and update related unit tests.
 
 ### 📝 Documentation
@@ -55,25 +64,25 @@ Initial public release.
 ### ✨ New Features
 
 - SPEC management:
-  - Create specs (requirements → design → tasks) via Codex CLI (`kfc.spec.create`).
+  - Create specs (requirements → design → tasks) via Codex CLI (`kiroCodex.spec.create`).
   - Navigate to requirements/design/tasks from the SPEC explorer.
-  - CodeLens for tasks in `tasks.md`: execute a single task via Codex and auto‑check it off (`kfc.spec.implTask`).
+  - CodeLens for tasks in `tasks.md`: execute a single task via Codex and auto‑check it off (`kiroCodex.spec.implTask`).
 - STEERING management:
-  - Generate initial project steering docs (product/tech/structure) (`kfc.steering.generateInitial`).
-  - Create custom steering documents (`kfc.steering.create`).
-  - Refine and delete steering docs with Codex updating related docs (`kfc.steering.refine`, `kfc.steering.delete`).
+  - Generate initial project steering docs (product/tech/structure) (`kiroCodex.steering.generateInitial`).
+  - Create custom steering documents (`kiroCodex.steering.create`).
+  - Refine and delete steering docs with Codex updating related docs (`kiroCodex.steering.refine`, `kiroCodex.steering.delete`).
 - PROMPTS view:
-  - Create Markdown prompts under `.codex/prompts` (`kfc.prompts.create`).
-  - Run prompts in a split terminal with Codex (`kfc.prompts.run`).
-  - Refresh prompts list (`kfc.prompts.refresh`).
+  - Create Markdown prompts under `.codex/prompts` (`kiroCodex.prompts.create`).
+  - Run prompts in a split terminal with Codex (`kiroCodex.prompts.run`).
+  - Refresh prompts list (`kiroCodex.prompts.refresh`).
 - Overview/Settings:
-  - Optional settings view and quick links (`kfc.settings.open`, `kfc.help.open`).
-  - Toggle view visibility from a command (`kfc.menu.open`).
+  - Optional settings view and quick links (`kiroCodex.settings.open`, `kiroCodex.help.open`).
+  - Toggle view visibility from a command (`kiroCodex.menu.open`).
 - Codex integration:
-  - Availability/version check and setup guidance (`kfc.codex.checkAvailability`).
+  - Availability/version check and setup guidance (`kiroCodex.codex.checkAvailability`).
   - Headless execution and split‑terminal invocation with retry/error handling.
 - Update checker:
-  - Manual update check command (`kfc.checkForUpdates`).
+  - Manual update check command (`kiroCodex.checkForUpdates`).
 
 ### 🔧 Improvements
 

--- a/README.md
+++ b/README.md
@@ -129,24 +129,24 @@ The Overview view provides quick access to settings, availability checks, and he
 
 Core commands registered by the extension:
 
-- `kfc.spec.create`: Create a new spec (requirements -> design -> tasks)
-- `kfc.spec.createWithAgents`: Disabled in this build
-- `kfc.spec.navigate.requirements` / `kfc.spec.navigate.design` / `kfc.spec.navigate.tasks`: Open spec documents
-- `kfc.spec.implTask`: Run an individual task from `tasks.md`
-- `kfc.spec.refresh`: Refresh the SPEC explorer
-- `kfc.steering.create`: Create a custom steering document
-- `kfc.steering.generateInitial`: Analyze the project and generate initial steering docs
-- `kfc.steering.refine`: Refine an existing steering document
-- `kfc.steering.delete`: Delete a steering document and update docs
-- `kfc.prompts.create` / `kfc.prompts.run` / `kfc.prompts.refresh`: Manage and run prompts
-- `kfc.settings.open`: Open workspace settings file `.codex/settings/kfc-settings.json`
-- `kfc.menu.open`: Toggle visibility of views (Specs / Steering; others when enabled)
-- `kfc.codex.checkAvailability`: Check Codex CLI availability and version
-- `kfc.checkForUpdates`: Manually trigger the extension update checker
+- `kiroCodex.spec.create`: Create a new spec (requirements -> design -> tasks)
+- `kiroCodex.spec.createWithAgents`: Disabled in this build
+- `kiroCodex.spec.navigate.requirements` / `kiroCodex.spec.navigate.design` / `kiroCodex.spec.navigate.tasks`: Open spec documents
+- `kiroCodex.spec.implTask`: Run an individual task from `tasks.md`
+- `kiroCodex.spec.refresh`: Refresh the SPEC explorer
+- `kiroCodex.steering.create`: Create a custom steering document
+- `kiroCodex.steering.generateInitial`: Analyze the project and generate initial steering docs
+- `kiroCodex.steering.refine`: Refine an existing steering document
+- `kiroCodex.steering.delete`: Delete a steering document and update docs
+- `kiroCodex.prompts.create` / `kiroCodex.prompts.run` / `kiroCodex.prompts.refresh`: Manage and run prompts
+- `kiroCodex.settings.open`: Open workspace settings file `.codex/settings/kiroCodex-settings.json`
+- `kiroCodex.menu.open`: Toggle visibility of views (Specs / Steering; others when enabled)
+- `kiroCodex.codex.checkAvailability`: Check Codex CLI availability and version
+- `kiroCodex.checkForUpdates`: Manually trigger the extension update checker
 
 ## Configuration
 
-Project-local settings are stored in `.codex/settings/kfc-settings.json` and only contain paths. UI visibility and Codex runtime options live in VS Code settings under the `kfc.*` namespace.
+Project-local settings are stored in `.codex/settings/kiroCodex-settings.json` and only contain paths. UI visibility and Codex runtime options live in VS Code settings under the `kiroCodex.*` namespace.
 
 Minimal settings file:
 
@@ -164,7 +164,7 @@ Minimal settings file:
 Notes:
 - Only the `paths.*` values are honored by the extension at runtime.
 - Changing `paths.*` may require a window reload to take effect.
-- The location of `kfc-settings.json` itself is fixed to `.codex/settings/kfc-settings.json` (editing `paths.settings` does not relocate the file).
+- The location of `kiroCodex-settings.json` itself is fixed to `.codex/settings/kiroCodex-settings.json` (editing `paths.settings` does not relocate the file).
 
 ## Workspace Structure
 
@@ -184,7 +184,7 @@ steering/                    # AI guidance documents
   tech.md                    # Technical standards
   structure.md               # Code organization
 settings/
-  kfc-settings.json          # Extension settings
+  kiroCodex-settings.json          # Extension settings
 ```
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kiro-for-codex",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kiro-for-codex",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
         "gray-matter": "^4.0.3",
         "handlebars": "^4.7.8",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "activationEvents": [
     "onStartupFinished"
   ],
-  "main": "./dist/extension.js",
+  "main": "dist/extension.js",
+  "extensionKind": ["workspace"],
   "scripts": {
     "build": "npm run package-web",
     "vscode:prepublish": "npm run package-web",
@@ -37,221 +38,292 @@
     "test:coverage": "jest --coverage"
   },
   "contributes": {
+    "configuration": {
+      "title": "Kiro for Codex",
+      "properties": {
+        "kiroCodex.paths.specs": {
+          "type": "string",
+          "default": ".codex/specs",
+          "description": "Relative path to specs directory"
+        },
+        "kiroCodex.paths.steering": {
+          "type": "string",
+          "default": ".codex/steering",
+          "description": "Relative path to steering directory"
+        },
+        "kiroCodex.paths.settings": {
+          "type": "string",
+          "default": ".codex/settings",
+          "description": "Relative path to settings directory (folder containing kiroCodex-settings.json)"
+        },
+        "kiroCodex.paths.prompts": {
+          "type": "string",
+          "default": ".codex/prompts",
+          "description": "Relative path to prompts directory"
+        },
+        "kiroCodex.views.specs.visible": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show Specs view in the Kiro activity container"
+        },
+        "kiroCodex.views.steering.visible": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show Steering view in the Kiro activity container"
+        },
+        "kiroCodex.views.prompts.visible": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show Prompts view in the Kiro activity container"
+        },
+        "kiroCodex.views.settings.visible": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show Settings view in the Kiro activity container"
+        },
+        "kiroCodex.codex.path": {
+          "type": "string",
+          "default": "codex",
+          "description": "Codex CLI executable name or path"
+        },
+        "kiroCodex.codex.defaultApprovalMode": {
+          "type": "string",
+          "enum": ["interactive", "auto-edit", "full-auto"],
+          "default": "interactive",
+          "description": "Default approval mode when invoking Codex CLI"
+        },
+        "kiroCodex.codex.defaultModel": {
+          "type": "string",
+          "default": "gpt-5",
+          "description": "Default model identifier for Codex CLI"
+        },
+        "kiroCodex.codex.timeout": {
+          "type": "number",
+          "default": 30000,
+          "description": "Command timeout in milliseconds for Codex CLI"
+        },
+        "kiroCodex.codex.terminalDelay": {
+          "type": "number",
+          "default": 1000,
+          "description": "Delay in milliseconds before writing to terminal to improve UX"
+        }
+      }
+    },
     "viewsContainers": {
       "activitybar": [
         {
-          "id": "kfc",
+          "id": "kiroCodex",
           "title": "Kiro for Codex",
           "icon": "./icons/kiro.svg"
         }
       ]
     },
     "views": {
-      "kfc": [
+      "kiroCodex": [
         {
-          "id": "kfc.views.specExplorer",
+          "id": "kiroCodex.views.specExplorer",
           "name": "Specs",
           "icon": "symbol-structure",
-          "when": "!(workbenchState == empty || workspaceFolderCount == 0) && config.kfc.views.specs.visible"
+          "when": "!(workbenchState == empty || workspaceFolderCount == 0) && config.kiroCodex.views.specs.visible"
         },
         {
-          "id": "kfc.views.steeringExplorer",
+          "id": "kiroCodex.views.steeringExplorer",
           "name": "Steering",
           "icon": "symbol-parameter",
-          "when": "!(workbenchState == empty || workspaceFolderCount == 0) && config.kfc.views.steering.visible"
+          "when": "!(workbenchState == empty || workspaceFolderCount == 0) && config.kiroCodex.views.steering.visible"
         },
         {
-          "id": "kfc.views.promptsExplorer",
+          "id": "kiroCodex.views.promptsExplorer",
           "name": "Prompts",
           "icon": "symbol-string",
-          "when": "!(workbenchState == empty || workspaceFolderCount == 0) && config.kfc.views.prompts.visible"
+          "when": "!(workbenchState == empty || workspaceFolderCount == 0) && config.kiroCodex.views.prompts.visible"
         },
         {
-          "id": "kfc.views.hooksStatus",
+          "id": "kiroCodex.views.hooksStatus",
           "name": "Hooks",
           "icon": "plug",
           "when": "false"
         },
         {
-          "id": "kfc.views.agentsExplorer",
+          "id": "kiroCodex.views.agentsExplorer",
           "name": "Agents",
           "icon": "account",
           "when": "false"
         },
         {
-          "id": "kfc.views.mcpServerStatus",
+          "id": "kiroCodex.views.mcpServerStatus",
           "name": "MCP Servers",
           "icon": "server",
           "when": "false"
         },
         {
-          "id": "kfc.views.overview",
+          "id": "kiroCodex.views.overview",
           "name": "Settings",
           "icon": "gear",
           "visibility": "collapsed",
-          "when": "!(workbenchState == empty || workspaceFolderCount == 0) && config.kfc.views.settings.visible"
+          "when": "!(workbenchState == empty || workspaceFolderCount == 0) && config.kiroCodex.views.settings.visible"
         }
       ]
     },
     "viewsWelcome": [
       {
-        "view": "kfc.views.promptsExplorer",
-        "contents": "Create and run prompts (.md) under .codex/prompts\n\n[$(plus) Create Prompt](command:kfc.prompts.create)\n[$(refresh) Refresh](command:kfc.prompts.refresh)"
+        "view": "kiroCodex.views.promptsExplorer",
+        "contents": "Create and run prompts (.md) under .codex/prompts\n\n[$(plus) Create Prompt](command:kiroCodex.prompts.create)\n[$(refresh) Refresh](command:kiroCodex.prompts.refresh)"
       },
       {
-        "view": "kfc.views.overview",
-        "contents": "Configure Kiro for Codex\n\n[$(gear) Open Settings](command:kfc.settings.open)\n[$(question) Help](command:kfc.help.open)"
+        "view": "kiroCodex.views.overview",
+        "contents": "Configure Kiro for Codex\n\n[$(gear) Open Settings](command:kiroCodex.settings.open)\n[$(question) Help](command:kiroCodex.help.open)"
       },
       {
-        "view": "kfc.views.specExplorer",
-        "contents": "Build complex features with structured planning\n\n[$(plus) Create New Spec](command:kfc.spec.create)"
+        "view": "kiroCodex.views.specExplorer",
+        "contents": "Build complex features with structured planning\n\n[$(plus) Create New Spec](command:kiroCodex.spec.create)"
       },
       {
-        "view": "kfc.views.hooksStatus",
+        "view": "kiroCodex.views.hooksStatus",
         "contents": "Hooks are temporarily disabled in this build"
       },
       {
-        "view": "kfc.views.steeringExplorer",
-        "contents": "[$(globe) Create User Rule](command:kfc.steering.createUserRule)\n\n[$(root-folder) Create Project Rule](command:kfc.steering.createProjectRule)"
+        "view": "kiroCodex.views.steeringExplorer",
+        "contents": "[$(globe) Create User Rule](command:kiroCodex.steering.createUserRule)\n\n[$(root-folder) Create Project Rule](command:kiroCodex.steering.createProjectRule)"
       },
       {
-        "view": "kfc.views.mcpServerStatus",
+        "view": "kiroCodex.views.mcpServerStatus",
         "contents": "MCP is temporarily disabled in this build"
       }
     ],
     "commands": [
       {
-        "command": "kfc.prompts.create",
+        "command": "kiroCodex.prompts.create",
         "title": "Create Prompt",
         "category": "Kiro for Codex",
         "icon": "$(plus)"
       },
       {
-        "command": "kfc.prompts.refresh",
+        "command": "kiroCodex.prompts.refresh",
         "title": "Refresh Prompts",
         "category": "Kiro for Codex",
         "icon": "$(refresh)"
       },
       {
-        "command": "kfc.prompts.run",
+        "command": "kiroCodex.prompts.run",
         "title": "Run Prompt",
         "category": "Kiro for Codex",
         "icon": "$(play)"
       },
       {
-        "command": "kfc.spec.create",
+        "command": "kiroCodex.spec.create",
         "title": "Create New Spec",
         "category": "Kiro for Codex",
         "icon": "$(plus)"
       },
       {
-        "command": "kfc.spec.createWithAgents",
+        "command": "kiroCodex.spec.createWithAgents",
         "title": "New Spec with Agents",
         "category": "Kiro for Codex",
         "icon": "$(sparkle)",
         "enablement": "false"
       },
       {
-        "command": "kfc.steering.create",
+        "command": "kiroCodex.steering.create",
         "title": "Create Custom Steering",
         "category": "Kiro for Codex",
         "icon": "$(plus)"
       },
       {
-        "command": "kfc.steering.generateInitial",
+        "command": "kiroCodex.steering.generateInitial",
         "title": "Init Steering",
         "category": "Kiro for Codex",
         "icon": "$(sparkle)"
       },
       {
-        "command": "kfc.steering.refine",
+        "command": "kiroCodex.steering.refine",
         "title": "Refine Steering",
         "category": "Kiro for Codex",
         "icon": "$(sparkle)"
       },
       {
-        "command": "kfc.spec.delete",
+        "command": "kiroCodex.spec.delete",
         "title": "Delete Spec",
         "category": "Kiro for Codex",
         "icon": "$(trash)"
       },
       {
-        "command": "kfc.steering.delete",
+        "command": "kiroCodex.steering.delete",
         "title": "Delete Steering",
         "category": "Kiro for Codex",
         "icon": "$(trash)"
       },
       {
-        "command": "kfc.steering.createUserRule",
+        "command": "kiroCodex.steering.createUserRule",
         "title": "Create User Rule",
         "category": "Kiro for Codex",
         "icon": "$(globe)"
       },
       {
-        "command": "kfc.steering.createProjectRule",
+        "command": "kiroCodex.steering.createProjectRule",
         "title": "Create Project Rule",
         "category": "Kiro for Codex",
         "icon": "$(root-folder)"
       },
       {
-        "command": "kfc.hooks.refresh",
+        "command": "kiroCodex.hooks.refresh",
         "title": "Refresh Hooks",
         "category": "Kiro for Codex",
         "icon": "$(refresh)",
         "enablement": "false"
       },
       {
-        "command": "kfc.mcp.refresh",
+        "command": "kiroCodex.mcp.refresh",
         "title": "Refresh MCP Status",
         "category": "Kiro for Codex",
         "icon": "$(refresh)",
         "enablement": "false"
       },
       {
-        "command": "kfc.settings.open",
+        "command": "kiroCodex.settings.open",
         "title": "Kiro Settings",
         "category": "Kiro for Codex",
         "icon": "$(gear)"
       },
       {
-        "command": "kfc.checkForUpdates",
+        "command": "kiroCodex.checkForUpdates",
         "title": "Check for Updates",
         "category": "Kiro for Codex",
         "icon": "$(sync)"
       },
       {
-        "command": "kfc.spec.refresh",
+        "command": "kiroCodex.spec.refresh",
         "title": "Refresh Specs",
         "category": "Kiro for Codex",
         "icon": "$(refresh)"
       },
       {
-        "command": "kfc.steering.refresh",
+        "command": "kiroCodex.steering.refresh",
         "title": "Refresh Steering",
         "category": "Kiro for Codex",
         "icon": "$(refresh)"
       },
       {
-        "command": "kfc.agents.refresh",
+        "command": "kiroCodex.agents.refresh",
         "title": "Refresh Agents",
         "category": "Kiro for Codex",
         "icon": "$(refresh)",
         "enablement": "false"
       },
       {
-        "command": "kfc.help.open",
+        "command": "kiroCodex.help.open",
         "title": "Kiro Help",
         "category": "Kiro for Codex",
         "icon": "$(question)"
       },
       {
-        "command": "kfc.menu.open",
+        "command": "kiroCodex.menu.open",
         "title": "Kiro Menu",
         "category": "Kiro for Codex",
         "icon": "$(ellipsis)"
       },
       {
-        "command": "kfc.spec.implTask",
+        "command": "kiroCodex.spec.implTask",
         "title": "Implement Task",
         "category": "Kiro for Codex"
       }
@@ -259,200 +331,120 @@
     "menus": {
       "view/title": [
         {
-          "command": "kfc.menu.open",
-          "when": "view == kfc.views.overview",
+          "command": "kiroCodex.menu.open",
+          "when": "view == kiroCodex.views.overview",
           "group": "navigation"
         },
         {
-          "command": "kfc.spec.create",
-          "when": "view == kfc.views.specExplorer",
+          "command": "kiroCodex.spec.create",
+          "when": "view == kiroCodex.views.specExplorer",
           "group": "navigation@1"
         },
         {
-          "command": "kfc.spec.createWithAgents",
+          "command": "kiroCodex.spec.createWithAgents",
           "when": "false",
           "group": "navigation@2"
         },
         {
-          "command": "kfc.spec.refresh",
-          "when": "view == kfc.views.specExplorer",
+          "command": "kiroCodex.spec.refresh",
+          "when": "view == kiroCodex.views.specExplorer",
           "group": "navigation@3"
         },
         {
-          "command": "kfc.steering.generateInitial",
-          "when": "view == kfc.views.steeringExplorer",
+          "command": "kiroCodex.steering.generateInitial",
+          "when": "view == kiroCodex.views.steeringExplorer",
           "group": "navigation@2"
         },
         {
-          "command": "kfc.steering.create",
-          "when": "view == kfc.views.steeringExplorer",
+          "command": "kiroCodex.steering.create",
+          "when": "view == kiroCodex.views.steeringExplorer",
           "group": "navigation@1"
         },
         {
-          "command": "kfc.steering.refresh",
-          "when": "view == kfc.views.steeringExplorer",
+          "command": "kiroCodex.steering.refresh",
+          "when": "view == kiroCodex.views.steeringExplorer",
           "group": "navigation@3"
         },
         {
-          "command": "kfc.prompts.create",
-          "when": "view == kfc.views.promptsExplorer",
+          "command": "kiroCodex.prompts.create",
+          "when": "view == kiroCodex.views.promptsExplorer",
           "group": "navigation@1"
         },
         {
-          "command": "kfc.prompts.refresh",
-          "when": "view == kfc.views.promptsExplorer",
+          "command": "kiroCodex.prompts.refresh",
+          "when": "view == kiroCodex.views.promptsExplorer",
           "group": "navigation@2"
         },
         {
-          "command": "kfc.mcp.refresh",
-          "when": "view == kfc.views.mcpServerStatus",
+          "command": "kiroCodex.mcp.refresh",
+          "when": "view == kiroCodex.views.mcpServerStatus",
           "group": "navigation"
         },
         {
-          "command": "kfc.hooks.refresh",
-          "when": "view == kfc.views.hooksStatus",
+          "command": "kiroCodex.hooks.refresh",
+          "when": "view == kiroCodex.views.hooksStatus",
           "group": "navigation"
         },
         {
-          "command": "kfc.agents.refresh",
-          "when": "view == kfc.views.agentsExplorer",
+          "command": "kiroCodex.agents.refresh",
+          "when": "view == kiroCodex.views.agentsExplorer",
           "group": "navigation"
         }
       ],
       "view/item/context": [
         {
-          "command": "kfc.spec.delete",
-          "when": "view == kfc.views.specExplorer && viewItem == spec",
+          "command": "kiroCodex.spec.delete",
+          "when": "view == kiroCodex.views.specExplorer && viewItem == spec",
           "group": "7_modification"
         },
         {
-          "command": "kfc.prompts.run",
-          "when": "view == kfc.views.promptsExplorer && viewItem == prompt",
+          "command": "kiroCodex.prompts.run",
+          "when": "view == kiroCodex.views.promptsExplorer && viewItem == prompt",
           "group": "inline"
         },
         {
-          "command": "kfc.steering.refine",
-          "when": "view == kfc.views.steeringExplorer && viewItem == steering-document",
+          "command": "kiroCodex.steering.refine",
+          "when": "view == kiroCodex.views.steeringExplorer && viewItem == steering-document",
           "group": "inline"
         },
         {
-          "command": "kfc.steering.delete",
-          "when": "view == kfc.views.steeringExplorer && viewItem == steering-document",
+          "command": "kiroCodex.steering.delete",
+          "when": "view == kiroCodex.views.steeringExplorer && viewItem == steering-document",
           "group": "7_modification"
         }
       ],
       "commandPalette": [
         {
-          "command": "kfc.spec.create"
+          "command": "kiroCodex.spec.create"
         },
         {
-          "command": "kfc.prompts.create",
+          "command": "kiroCodex.prompts.create",
           "when": "workspaceFolderCount > 0"
         },
         {
-          "command": "kfc.steering.create",
+          "command": "kiroCodex.steering.create",
           "when": "workspaceFolderCount > 0"
         },
         {
-          "command": "kfc.checkForUpdates"
+          "command": "kiroCodex.checkForUpdates"
         },
         {
-          "command": "kfc.spec.createWithAgents",
+          "command": "kiroCodex.spec.createWithAgents",
           "when": "false"
         },
         {
-          "command": "kfc.hooks.refresh",
+          "command": "kiroCodex.hooks.refresh",
           "when": "false"
         },
         {
-          "command": "kfc.mcp.refresh",
+          "command": "kiroCodex.mcp.refresh",
           "when": "false"
         },
         {
-          "command": "kfc.agents.refresh",
+          "command": "kiroCodex.agents.refresh",
           "when": "false"
         }
       ]
-    },
-    "configuration": {
-      "title": "Kiro for Codex",
-      "properties": {
-        "kfc.autoRefreshSpecs": {
-          "type": "boolean",
-          "default": true,
-          "description": "Automatically refresh specs when requirements are saved"
-        },
-        "kfc.showWelcomeMessage": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show welcome message on startup"
-        },
-        "kfc.views.specs.visible": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show Specs view"
-        },
-        "kfc.views.prompts.visible": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show Prompts view"
-        },
-        "kfc.views.agents.visible": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show Agents view (temporarily disabled)"
-        },
-        "kfc.views.hooks.visible": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show Agent Hooks view"
-        },
-        "kfc.views.steering.visible": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show Agent Steering view"
-        },
-        "kfc.views.mcp.visible": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show MCP Servers view"
-        },
-        "kfc.views.settings.visible": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show Settings view"
-        },
-        "kfc.codex.path": {
-          "type": "string",
-          "default": "codex",
-          "description": "Path to Codex CLI executable"
-        },
-        "kfc.codex.defaultApprovalMode": {
-          "type": "string",
-          "default": "interactive",
-          "enum": [
-            "interactive",
-            "auto-edit",
-            "full-auto"
-          ],
-          "description": "Default approval mode for Codex operations"
-        },
-        "kfc.codex.defaultModel": {
-          "type": "string",
-          "default": "gpt-5",
-          "description": "Default model to use with Codex CLI"
-        },
-        "kfc.codex.timeout": {
-          "type": "number",
-          "default": 30000,
-          "description": "Timeout for Codex CLI operations in milliseconds"
-        },
-        "kfc.codex.terminalDelay": {
-          "type": "number",
-          "default": 1000,
-          "description": "Delay before sending commands to terminal in milliseconds"
-        }
-      }
     }
   },
   "dependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,8 @@
 // VSCode configuration namespace for this extension
-export const VSC_CONFIG_NAMESPACE = 'kfc';
+export const VSC_CONFIG_NAMESPACE = 'kiroCodex';
 
 // File names
-export const CONFIG_FILE_NAME = 'kfc-settings.json';
+export const CONFIG_FILE_NAME = 'kiroCodex-settings.json';
 
 // Default configuration
 export const DEFAULT_CONFIG = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,27 +85,27 @@ export async function activate(context: vscode.ExtensionContext) {
     steeringExplorer.setSteeringManager(steeringManager);
 
     context.subscriptions.push(
-        vscode.window.registerTreeDataProvider('kfc.views.overview', overviewProvider),
-        vscode.window.registerTreeDataProvider('kfc.views.specExplorer', specExplorer),
-        vscode.window.registerTreeDataProvider('kfc.views.steeringExplorer', steeringExplorer)
+        vscode.window.registerTreeDataProvider('kiroCodex.views.overview', overviewProvider),
+        vscode.window.registerTreeDataProvider('kiroCodex.views.specExplorer', specExplorer),
+        vscode.window.registerTreeDataProvider('kiroCodex.views.steeringExplorer', steeringExplorer)
     );
     if (ENABLE_AGENTS_UI && agentsExplorer) {
         context.subscriptions.push(
-            vscode.window.registerTreeDataProvider('kfc.views.agentsExplorer', agentsExplorer)
+            vscode.window.registerTreeDataProvider('kiroCodex.views.agentsExplorer', agentsExplorer)
         );
     }
     context.subscriptions.push(
-        vscode.window.registerTreeDataProvider('kfc.views.promptsExplorer', promptsExplorer)
+        vscode.window.registerTreeDataProvider('kiroCodex.views.promptsExplorer', promptsExplorer)
     );
     if (ENABLE_HOOKS_UI && hooksExplorer) {
         context.subscriptions.push(
-            vscode.window.registerTreeDataProvider('kfc.views.hooksStatus', hooksExplorer)
+            vscode.window.registerTreeDataProvider('kiroCodex.views.hooksStatus', hooksExplorer)
         );
     }
 
     if (ENABLE_MCP_UI && mcpExplorer) {
         context.subscriptions.push(
-            vscode.window.registerTreeDataProvider('kfc.views.mcpServerStatus', mcpExplorer)
+            vscode.window.registerTreeDataProvider('kiroCodex.views.mcpServerStatus', mcpExplorer)
         );
     }
 
@@ -164,7 +164,7 @@ async function initializeDefaultSettings() {
         // Directory might already exist
     }
 
-    // Create kfc-settings.json in .codex directory
+    // Create kiroCodex-settings.json in .codex directory
     const codexSettingsFile = vscode.Uri.joinPath(codexSettingsDir, CONFIG_FILE_NAME);
 
     try {
@@ -259,8 +259,8 @@ function registerCommands(
 ) {
 
     // Spec commands
-    const createSpecCommand = vscode.commands.registerCommand('kfc.spec.create', async () => {
-        outputChannel.appendLine('\n=== COMMAND kfc.spec.create TRIGGERED ===');
+    const createSpecCommand = vscode.commands.registerCommand('kiroCodex.spec.create', async () => {
+        outputChannel.appendLine('\n=== COMMAND kiroCodex.spec.create TRIGGERED ===');
         outputChannel.appendLine(`Time: ${new Date().toLocaleTimeString()}`);
 
         try {
@@ -272,7 +272,7 @@ function registerCommands(
     });
 
     // Guard: "New Spec with Agents" is disabled for Codex build
-    const createSpecWithAgentsCommand = vscode.commands.registerCommand('kfc.spec.createWithAgents', async () => {
+    const createSpecWithAgentsCommand = vscode.commands.registerCommand('kiroCodex.spec.createWithAgents', async () => {
         if (!ENABLE_SPEC_AGENTS) {
             vscode.window.showInformationMessage('New Spec with Agents is disabled in this build.');
             return;
@@ -288,19 +288,19 @@ function registerCommands(
     context.subscriptions.push(createSpecCommand, createSpecWithAgentsCommand);
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('kfc.spec.navigate.requirements', async (specName: string) => {
+        vscode.commands.registerCommand('kiroCodex.spec.navigate.requirements', async (specName: string) => {
             await specManager.navigateToDocument(specName, 'requirements');
         }),
 
-        vscode.commands.registerCommand('kfc.spec.navigate.design', async (specName: string) => {
+        vscode.commands.registerCommand('kiroCodex.spec.navigate.design', async (specName: string) => {
             await specManager.navigateToDocument(specName, 'design');
         }),
 
-        vscode.commands.registerCommand('kfc.spec.navigate.tasks', async (specName: string) => {
+        vscode.commands.registerCommand('kiroCodex.spec.navigate.tasks', async (specName: string) => {
             await specManager.navigateToDocument(specName, 'tasks');
         }),
 
-        vscode.commands.registerCommand('kfc.spec.implTask', async (documentUri: vscode.Uri, lineNumber: number, taskDescription: string) => {
+        vscode.commands.registerCommand('kiroCodex.spec.implTask', async (documentUri: vscode.Uri, lineNumber: number, taskDescription: string) => {
             outputChannel.appendLine(`[Task Execute] Line ${lineNumber + 1}: ${taskDescription}`);
 
             // Update task status to completed
@@ -315,7 +315,7 @@ function registerCommands(
             // Use Codex CLI to execute task
             await specManager.implTask(documentUri.fsPath, taskDescription);
         }),
-        vscode.commands.registerCommand('kfc.spec.refresh', async () => {
+        vscode.commands.registerCommand('kiroCodex.spec.refresh', async () => {
             outputChannel.appendLine('[Manual Refresh] Refreshing spec explorer...');
             specExplorer.refresh();
         })
@@ -323,21 +323,21 @@ function registerCommands(
 
     // Steering commands
     context.subscriptions.push(
-        vscode.commands.registerCommand('kfc.steering.create', async () => {
+        vscode.commands.registerCommand('kiroCodex.steering.create', async () => {
             await steeringManager.createCustom();
         }),
 
-        vscode.commands.registerCommand('kfc.steering.generateInitial', async () => {
+        vscode.commands.registerCommand('kiroCodex.steering.generateInitial', async () => {
             await steeringManager.init();
         }),
 
-        vscode.commands.registerCommand('kfc.steering.refine', async (item: any) => {
+        vscode.commands.registerCommand('kiroCodex.steering.refine', async (item: any) => {
             // Item is always from tree view
             const uri = vscode.Uri.file(item.resourcePath);
             await steeringManager.refine(uri);
         }),
 
-        vscode.commands.registerCommand('kfc.steering.delete', async (item: any) => {
+        vscode.commands.registerCommand('kiroCodex.steering.delete', async (item: any) => {
             outputChannel.appendLine(`[Steering] Deleting: ${item.label}`);
 
             // Use SteeringManager to delete the document
@@ -349,22 +349,22 @@ function registerCommands(
         }),
 
         // Configuration commands
-        vscode.commands.registerCommand('kfc.steering.createUserRule', async () => {
+        vscode.commands.registerCommand('kiroCodex.steering.createUserRule', async () => {
             await steeringManager.createUserConfiguration();
         }),
 
-        vscode.commands.registerCommand('kfc.steering.createProjectRule', async () => {
+        vscode.commands.registerCommand('kiroCodex.steering.createProjectRule', async () => {
             await steeringManager.createProjectDocumentation();
         }),
 
-        vscode.commands.registerCommand('kfc.steering.refresh', async () => {
+        vscode.commands.registerCommand('kiroCodex.steering.refresh', async () => {
             outputChannel.appendLine('[Manual Refresh] Refreshing steering explorer...');
             steeringExplorer.refresh();
         }),
 
         // Agents commands
         ...(ENABLE_AGENTS_UI && agentsExplorer ? [
-            vscode.commands.registerCommand('kfc.agents.refresh', async () => {
+            vscode.commands.registerCommand('kiroCodex.agents.refresh', async () => {
                 outputChannel.appendLine('[Manual Refresh] Refreshing agents explorer...');
                 agentsExplorer.refresh();
             })
@@ -397,7 +397,7 @@ function registerCommands(
 
     // Spec delete command
     context.subscriptions.push(
-        vscode.commands.registerCommand('kfc.spec.delete', async (item: any) => {
+        vscode.commands.registerCommand('kiroCodex.spec.delete', async (item: any) => {
             await specManager.delete(item.label);
         })
     );
@@ -408,10 +408,10 @@ function registerCommands(
     // Hooks commands
     if (ENABLE_HOOKS_UI && hooksExplorer) {
         context.subscriptions.push(
-            vscode.commands.registerCommand('kfc.hooks.refresh', () => {
+            vscode.commands.registerCommand('kiroCodex.hooks.refresh', () => {
                 hooksExplorer.refresh();
             }),
-            vscode.commands.registerCommand('kfc.hooks.copyCommand', async (command: string) => {
+            vscode.commands.registerCommand('kiroCodex.hooks.copyCommand', async (command: string) => {
                 await vscode.env.clipboard.writeText(command);
             })
         );
@@ -420,7 +420,7 @@ function registerCommands(
     // MCP commands (only when enabled)
     if (ENABLE_MCP_UI && mcpExplorer) {
         context.subscriptions.push(
-            vscode.commands.registerCommand('kfc.mcp.refresh', () => {
+            vscode.commands.registerCommand('kiroCodex.mcp.refresh', () => {
                 mcpExplorer.refresh();
             })
         );
@@ -428,11 +428,11 @@ function registerCommands(
 
     // Prompts commands
     context.subscriptions.push(
-        vscode.commands.registerCommand('kfc.prompts.refresh', async () => {
+        vscode.commands.registerCommand('kiroCodex.prompts.refresh', async () => {
             outputChannel.appendLine('[Manual Refresh] Refreshing prompts explorer...');
             promptsExplorer.refresh();
         }),
-        vscode.commands.registerCommand('kfc.prompts.create', async () => {
+        vscode.commands.registerCommand('kiroCodex.prompts.create', async () => {
             const ws = vscode.workspace.workspaceFolders?.[0];
             if (!ws) {
                 vscode.window.showErrorMessage('No workspace folder found');
@@ -458,7 +458,7 @@ function registerCommands(
                 vscode.window.showErrorMessage(`Failed to create prompt: ${e}`);
             }
         }),
-        vscode.commands.registerCommand('kfc.prompts.run', async (filePathOrItem?: any) => {
+        vscode.commands.registerCommand('kiroCodex.prompts.run', async (filePathOrItem?: any) => {
             try {
                 let target: string | undefined;
 
@@ -493,13 +493,13 @@ function registerCommands(
         
         // Group the following commands in a single subscriptions push
         context.subscriptions.push(
-        vscode.commands.registerCommand('kfc.checkForUpdates', async () => {
+        vscode.commands.registerCommand('kiroCodex.checkForUpdates', async () => {
             outputChannel.appendLine('Manual update check requested');
             await updateChecker.checkForUpdates(true); // Force check
         }),
 
         // Overview and settings commands
-        vscode.commands.registerCommand('kfc.settings.open', async () => {
+        vscode.commands.registerCommand('kiroCodex.settings.open', async () => {
             outputChannel.appendLine('Opening Kiro settings...');
 
             const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
@@ -519,7 +519,7 @@ function registerCommands(
                 // Directory might already exist
             }
 
-            // Create or open kfc-settings.json
+            // Create or open kiroCodex-settings.json
             const settingsFile = vscode.Uri.joinPath(settingsDir, CONFIG_FILE_NAME);
 
             try {
@@ -541,19 +541,19 @@ function registerCommands(
             await vscode.window.showTextDocument(document);
         }),
 
-        vscode.commands.registerCommand('kfc.help.open', async () => {
+        vscode.commands.registerCommand('kiroCodex.help.open', async () => {
             outputChannel.appendLine('Opening Kiro help...');
             const helpUrl = 'https://github.com/atman-33/kiro-for-codex#readme';
             vscode.env.openExternal(vscode.Uri.parse(helpUrl));
         }),
 
-        vscode.commands.registerCommand('kfc.menu.open', async () => {
+        vscode.commands.registerCommand('kiroCodex.menu.open', async () => {
             outputChannel.appendLine('Opening Kiro menu...');
             await toggleViews();
         }),
 
         // Codex availability check command
-        vscode.commands.registerCommand('kfc.codex.checkAvailability', async () => {
+        vscode.commands.registerCommand('kiroCodex.codex.checkAvailability', async () => {
             const availabilityResult = await codexProvider.getCodexAvailabilityStatus();
 
             const statusMessage = availabilityResult.isAvailable
@@ -614,10 +614,10 @@ function setupFileWatchers(
 
     context.subscriptions.push(codexWatcher);
 
-    // Watch for changes in workspace Codex settings (.codex/settings/kfc-settings.json)
+    // Watch for changes in workspace Codex settings (.codex/settings/kiroCodex-settings.json)
     const wsFolder = vscode.workspace.workspaceFolders?.[0];
     if (wsFolder) {
-        const settingsPattern = new vscode.RelativePattern(wsFolder, '.codex/settings/kfc-settings.json');
+        const settingsPattern = new vscode.RelativePattern(wsFolder, '.codex/settings/kiroCodex-settings.json');
         const codexSettingsWatcher = vscode.workspace.createFileSystemWatcher(settingsPattern);
 
         codexSettingsWatcher.onDidChange(() => {

--- a/src/features/agents/agent-manager.ts
+++ b/src/features/agents/agent-manager.ts
@@ -67,7 +67,7 @@ export class AgentManager {
             return;
         }
 
-        const targetDir = path.join(this.workspaceRoot, '.codex/agents/kfc');
+        const targetDir = path.join(this.workspaceRoot, '.codex/agents/kiroCodex');
 
         try {
             // Ensure target directory exists
@@ -126,14 +126,14 @@ export class AgentManager {
     async getAgentList(type: 'project' | 'user' | 'all' = 'all'): Promise<AgentInfo[]> {
         const agents: AgentInfo[] = [];
 
-        // Get project agents (excluding kfc built-in agents)
+        // Get project agents (excluding kiroCodex built-in agents)
         if (type === 'project' || type === 'all') {
             if (this.workspaceRoot) {
                 const projectAgentsPath = path.join(this.workspaceRoot, '.codex/agents');
                 const projectAgents = await this.getAgentsFromDirectory(
                     projectAgentsPath,
                     'project',
-                    true  // exclude kfc directory
+                    true  // exclude kiroCodex directory
                 );
                 agents.push(...projectAgents);
             }
@@ -176,9 +176,9 @@ export class AgentManager {
             for (const [fileName, fileType] of entries) {
                 const fullPath = path.join(dirPath, fileName);
 
-                // Skip kfc directory if excludeKfc is true
-                if (excludeKfc && fileName === 'kfc' && fileType === vscode.FileType.Directory) {
-                    this.outputChannel.appendLine(`[AgentManager] Skipping kfc directory (built-in agents)`);
+                // Skip kiroCodex directory if excludeKfc is true
+                if (excludeKfc && fileName === 'kiroCodex' && fileType === vscode.FileType.Directory) {
+                    this.outputChannel.appendLine(`[AgentManager] Skipping kiroCodex directory (built-in agents)`);
                     continue;
                 }
 
@@ -256,7 +256,7 @@ export class AgentManager {
      */
     checkAgentExists(agentName: string, location: 'project' | 'user'): boolean {
         const basePath = location === 'project'
-            ? (this.workspaceRoot ? path.join(this.workspaceRoot, '.codex/agents/kfc') : null)
+            ? (this.workspaceRoot ? path.join(this.workspaceRoot, '.codex/agents/kiroCodex') : null)
             : path.join(os.homedir(), '.codex/agents');
 
         if (!basePath) {
@@ -273,7 +273,7 @@ export class AgentManager {
     getAgentPath(agentName: string): string | null {
         // Check project agents first
         if (this.workspaceRoot) {
-            const projectPath = path.join(this.workspaceRoot, '.codex/agents/kfc', `${agentName}.md`);
+            const projectPath = path.join(this.workspaceRoot, '.codex/agents/kiroCodex', `${agentName}.md`);
             if (fs.existsSync(projectPath)) {
                 return projectPath;
             }

--- a/src/providers/hooks-explorer-provider.ts
+++ b/src/providers/hooks-explorer-provider.ts
@@ -132,7 +132,7 @@ export class HooksExplorerProvider implements vscode.TreeDataProvider<HookItem> 
                             'hook-command', // Use specific contextValue
                             `${element.id}-command-${index}`,
                             {
-                                command: 'kfc.hooks.copyCommand',
+                                command: 'kiroCodex.hooks.copyCommand',
                                 title: 'Copy Command',
                                 arguments: [hook.command]
                             },

--- a/src/providers/spec-explorer-provider.ts
+++ b/src/providers/spec-explorer-provider.ts
@@ -80,7 +80,7 @@ export class SpecExplorerProvider implements vscode.TreeDataProvider<SpecItem> {
                     element.specName!,
                     'requirements',
                     {
-                        command: 'kfc.spec.navigate.requirements',
+                        command: 'kiroCodex.spec.navigate.requirements',
                         title: 'Open Requirements',
                         arguments: [element.specName]
                     },
@@ -94,7 +94,7 @@ export class SpecExplorerProvider implements vscode.TreeDataProvider<SpecItem> {
                     element.specName!,
                     'design',
                     {
-                        command: 'kfc.spec.navigate.design',
+                        command: 'kiroCodex.spec.navigate.design',
                         title: 'Open Design',
                         arguments: [element.specName]
                     },
@@ -108,7 +108,7 @@ export class SpecExplorerProvider implements vscode.TreeDataProvider<SpecItem> {
                     element.specName!,
                     'tasks',
                     {
-                        command: 'kfc.spec.navigate.tasks',
+                        command: 'kiroCodex.spec.navigate.tasks',
                         title: 'Open Tasks',
                         arguments: [element.specName]
                     },

--- a/src/providers/spec-task-code-lens-provider.ts
+++ b/src/providers/spec-task-code-lens-provider.ts
@@ -34,7 +34,7 @@ export class SpecTaskCodeLensProvider implements vscode.CodeLensProvider {
                 const codeLens = new vscode.CodeLens(range, {
                     title: "$(play) Start Task",
                     tooltip: "Click to execute this task",
-                    command: "kfc.spec.implTask",
+                    command: "kiroCodex.spec.implTask",
                     arguments: [document.uri, i, taskDescription]
                 });
 

--- a/src/providers/steering-explorer-provider.ts
+++ b/src/providers/steering-explorer-provider.ts
@@ -122,7 +122,7 @@ export class SteeringExplorerProvider implements vscode.TreeDataProvider<Steerin
                     '',
                     this.context,
                     {
-                        command: 'kfc.steering.createUserRule',
+                        command: 'kiroCodex.steering.createUserRule',
                         title: 'Create Global Configuration'
                     }
                 ));
@@ -136,7 +136,7 @@ export class SteeringExplorerProvider implements vscode.TreeDataProvider<Steerin
                     '',
                     this.context,
                     {
-                        command: 'kfc.steering.createProjectRule',
+                        command: 'kiroCodex.steering.createProjectRule',
                         title: 'Create Agents Configuration'
                     }
                 ));

--- a/src/utils/config-manager.ts
+++ b/src/utils/config-manager.ts
@@ -2,8 +2,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { CONFIG_FILE_NAME, DEFAULT_PATHS } from '../constants';
 
-// Minimal project-local settings persisted under .codex/settings/kfc-settings.json
-// Only "paths" are honored by the extension. Other runtime configs live in VS Code settings (kfc.*).
+// Minimal project-local settings persisted under .codex/settings/kiroCodex-settings.json
+// Only "paths" are honored by the extension. Other runtime configs live in VS Code settings (kiroCodex.*).
 export interface KfcSettings {
     paths: {
         specs: string;

--- a/src/utils/update-checker.ts
+++ b/src/utils/update-checker.ts
@@ -2,8 +2,8 @@ import * as vscode from 'vscode';
 import { NotificationUtils } from './notification-utils';
 
 export class UpdateChecker {
-    private static readonly SKIP_VERSION_KEY = 'kfc.skipVersion';
-    private static readonly LAST_CHECK_KEY = 'kfc.lastUpdateCheck';
+    private static readonly SKIP_VERSION_KEY = 'kiroCodex.skipVersion';
+    private static readonly LAST_CHECK_KEY = 'kiroCodex.lastUpdateCheck';
     private static readonly CHECK_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours
 
     constructor(

--- a/tests/unit/config/package-menus.test.ts
+++ b/tests/unit/config/package-menus.test.ts
@@ -4,10 +4,9 @@ describe('package.json menus', () => {
   test('adds inline Run Prompt for Prompts view items', () => {
     const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
     const menus = pkg?.contributes?.menus?.['view/item/context'] || [];
-    const entry = menus.find((m: any) => m.command === 'kfc.prompts.run');
+    const entry = menus.find((m: any) => m.command === 'kiroCodex.prompts.run');
     expect(entry).toBeTruthy();
-    expect(entry.when).toContain('kfc.views.promptsExplorer');
+    expect(entry.when).toContain('kiroCodex.views.promptsExplorer');
     expect(entry.group).toBe('inline');
   });
 });
-

--- a/tests/unit/features/agents/agent-manager.test.ts
+++ b/tests/unit/features/agents/agent-manager.test.ts
@@ -119,7 +119,7 @@ describe('AgentManager', () => {
     describe('2. Built-in Agents Initialization', () => {
         test('TC-AM-002: Successfully initialize built-in agents', async () => {
             // Arrange
-            const targetPath = path.join(mockWorkspaceRoot, '.codex', 'agents', 'kfc');
+            const targetPath = path.join(mockWorkspaceRoot, '.codex', 'agents', 'kiroCodex');
 
             // Mock stat to throw (file doesn't exist)
             (vscode.workspace.fs.stat as jest.Mock).mockRejectedValue(new Error('File not found'));
@@ -310,7 +310,7 @@ description: No tools
     describe('4. Agent Path Management', () => {
         test('TC-AM-009: Get agent path', () => {
             // Arrange (normalize path comparison for cross-OS)
-            const expectedNeedle = path.join('.codex', 'agents', 'kfc', 'test-agent.md');
+            const expectedNeedle = path.join('.codex', 'agents', 'kiroCodex', 'test-agent.md');
             (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
                 return path.normalize(p).includes(path.normalize(expectedNeedle));
             });
@@ -319,7 +319,7 @@ description: No tools
             const agentPath = agentManager.getAgentPath('test-agent');
 
             // Assert
-            const expectedFull = path.join(mockWorkspaceRoot, '.codex', 'agents', 'kfc', 'test-agent.md');
+            const expectedFull = path.join(mockWorkspaceRoot, '.codex', 'agents', 'kiroCodex', 'test-agent.md');
             expect(agentPath).toBe(expectedFull);
         });
 
@@ -336,7 +336,7 @@ description: No tools
 
         test('TC-AM-011: Check agent existence', () => {
             // Arrange
-            const expectedExisting = path.join('kfc', 'existing-agent.md');
+            const expectedExisting = path.join('kiroCodex', 'existing-agent.md');
             (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
                 // Only return true for paths that contain 'existing-agent.md' (normalized)
                 return path.normalize(p).includes(path.normalize(expectedExisting));

--- a/tests/unit/utils/update-checker.test.ts
+++ b/tests/unit/utils/update-checker.test.ts
@@ -200,13 +200,13 @@ describe('UpdateChecker', () => {
             // Wait for the promise to resolve
             await new Promise(resolve => setTimeout(resolve, 0));
 
-            expect(mockGlobalState.update).toHaveBeenCalledWith('kfc.skipVersion', '0.1.9');
+            expect(mockGlobalState.update).toHaveBeenCalledWith('kiroCodex.skipVersion', '0.1.9');
         });
 
         it('should not show notification for skipped version', async () => {
             // Set up skipped version
             mockGlobalState.get.mockImplementation((key: string) => {
-                if (key === 'kfc.skipVersion') return '0.1.9';
+                if (key === 'kiroCodex.skipVersion') return '0.1.9';
                 return undefined;
             });
 
@@ -231,7 +231,7 @@ describe('UpdateChecker', () => {
             // Set last check to 1 hour ago
             const oneHourAgo = Date.now() - (60 * 60 * 1000);
             mockGlobalState.get.mockImplementation((key: string) => {
-                if (key === 'kfc.lastUpdateCheck') return oneHourAgo;
+                if (key === 'kiroCodex.lastUpdateCheck') return oneHourAgo;
                 return undefined;
             });
 
@@ -244,7 +244,7 @@ describe('UpdateChecker', () => {
             // Set last check to 1 hour ago
             const oneHourAgo = Date.now() - (60 * 60 * 1000);
             mockGlobalState.get.mockImplementation((key: string) => {
-                if (key === 'kfc.lastUpdateCheck') return oneHourAgo;
+                if (key === 'kiroCodex.lastUpdateCheck') return oneHourAgo;
                 return undefined;
             });
 


### PR DESCRIPTION
Rename and related updates to prevent extension naming collision with the Kiro for Claude Code extension. Aligns with project Steering and
  constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Breaking Changes
  * Public namespace renamed from kfc to kiroCodex across commands, settings, views, and menus.
  * Settings file renamed to .codex/settings/kiroCodex-settings.json; built-in agents folder renamed accordingly.
  * Previously stored update-check preferences are reset.

* New Features
  * New kiroCodex.* configuration options for paths, view visibility, and Codex defaults.
  * Prompts path added; Prompts view enabled by default.

* UX Improvements
  * Starting a spec task now auto-marks it as completed.
  * Save confirmation added for agent Markdown files.

* Documentation
  * README and inline docs updated to reflect new namespace and configuration names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #27