### PR TITLE
Add .gitattributes and refactor filename conversion logic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Use LF for all text files by default
+* text=auto eol=lf
+
+# Explicit rules for specific file types
+*.bat text eol=crlf   # Windows batch files should use CRLF
+*.ps1 text eol=crlf   # PowerShell scripts should use CRLF
+*.sh  text eol=lf     # Shell scripts should use LF
+*.ts  text eol=lf     # TypeScript files should use LF
+*.js  text eol=lf     # JavaScript files should use LF
+*.json text eol=lf    # JSON files should use LF
+*.yml  text eol=lf    # YAML files should use LF
+*.yaml text eol=lf    # YAML files should use LF
+*.md   text eol=lf    # Markdown files should use LF
+
+# Do not perform line ending conversions on binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.exe binary
+*.dll binary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kiro-for-codex",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kiro-for-codex",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "gray-matter": "^4.0.3",
         "handlebars": "^4.7.8",

--- a/scripts/build-prompts.js
+++ b/scripts/build-prompts.js
@@ -89,10 +89,8 @@ function generateIndex(outputDir) {
   const files = walk(outputDir);
 
   // Create export lines with stable camelCase aliases
-  const toCamel = (name) => name
-    .replace(/\.ts$/, '')
-    .split('/')
-    .pop()
+  const toCamel = (filePath) => path
+    .basename(filePath, '.ts')
     .split('-')
     .map((seg, i) => (i === 0 ? seg : seg.charAt(0).toUpperCase() + seg.slice(1)))
     .join('');


### PR DESCRIPTION
Introduce a .gitattributes file to standardize line endings across various file types and bump the package version to 0.4.0. Refactor the filename conversion logic to improve maintainability and robustness.