### PR TITLE
chore: improve release workflow with tag existence check and dispatch

### DIFF
--- a/.github/workflows/release-only.yml
+++ b/.github/workflows/release-only.yml
@@ -27,7 +27,9 @@ jobs:
 
       - name: Read package.json version
         id: pkg
-        run: echo "PKG_VERSION=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "PKG_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Validate input version matches package.json
         run: |
@@ -47,15 +49,18 @@ jobs:
       # NOTE: This workflow does not modify CHANGELOG.md.
       # If no section exists for the version, the Release job will inject a placeholder.
 
-      - name: Ensure tag does not already exist on origin
+      - name: Check if tag exists on origin
+        id: tag_check
         run: |
           VERSION="${{ inputs.version }}"
           if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
-            echo "::error::Tag v$VERSION already exists on origin. Choose a different version or delete the existing tag."
-            exit 1
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create and push tag
+        if: steps.tag_check.outputs.exists == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -63,7 +68,26 @@ jobs:
           git tag -a "v$VERSION" -m "chore(release): v$VERSION"
           git push origin "refs/tags/v$VERSION"
 
+      - name: Trigger release workflow
+        if: steps.tag_check.outputs.exists == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release.yml',
+              ref: context.ref,
+              inputs: {
+                version: '${{ inputs.version }}'
+              }
+            });
+
       - name: Summary
         run: |
-          echo "Tagged commit $(git rev-parse --short HEAD) as v${{ inputs.version }}."
-          echo "This will trigger .github/workflows/release.yml (push: tags: v*)."
+          if [ "${{ steps.tag_check.outputs.exists }}" = "true" ]; then
+            echo "Tag v${{ inputs.version }} already existed. Triggered release.yml via workflow_dispatch instead of creating a new tag."
+          else
+            echo "Tagged commit $(git rev-parse --short HEAD) as v${{ inputs.version }}."
+            echo "This push triggers .github/workflows/release.yml (push: tags: v*)."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Existing version to publish (e.g., 1.2.3)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -18,6 +24,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/v{0}', github.event.inputs.version) || github.ref }}
       
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -42,9 +49,28 @@ jobs:
       - name: Build VSIX
         run: vsce package
         
-      - name: Get version from tag
+      - name: Determine release version
         id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        env:
+          INPUT_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || '' }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::Unable to determine release version." >&2
+            exit 1
+          fi
+
+          if ! git rev-parse "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag v$VERSION not found in repository." >&2
+            exit 1
+          fi
+
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
         
       - name: Get previous tag
         id: get_previous_tag


### PR DESCRIPTION
Added tag existence check in release-only.yml to prevent duplicate tags and trigger release workflow via workflow_dispatch when tag exists. Modified release.yml to handle both tag push and workflow_dispatch triggers. Updated release process documentation to reflect these changes.

Key changes:
- Added tag check step with conditional workflow dispatch
- Enhanced version detection logic in release.yml
- Updated release process documentation
- Improved error handling and messaging

This prevents duplicate tag errors and provides a fallback mechanism when tags already exist.