### PR TITLE
fix(ci): add actions write permission to release workflow

### DIFF
--- a/.github/workflows/release-only.yml
+++ b/.github/workflows/release-only.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag:


### PR DESCRIPTION
Added 'actions: write' permission to the GitHub release workflow to allow the workflow to interact with GitHub Actions API. This is necessary for any actions that require modifying workflow runs or artifacts during the release process.