### PR TITLE
fix(release): add tag_name to GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: v${{ steps.get_version.outputs.VERSION }}
           files: '*.vsix'
           generate_release_notes: true
           name: Release v${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Added explicit tag_name parameter to the GitHub release workflow to ensure consistent version tagging. The tag will now match the release version (vX.Y.Z) generated by the get_version step, aligning with the release name format. This provides better consistency between the release name and its associated tag.