### PR TITLE
chore: bump package version from 0.4.0 to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "kiro-for-codex",
-      "version": "0.4.0",
+      "version": "0.6.0",
       "dependencies": {
         "gray-matter": "^4.0.3",
         "handlebars": "^4.7.8",


### PR DESCRIPTION
Update the project version in package-lock.json to reflect the latest release. This ensures consistency between the package metadata and the actual deployed version.